### PR TITLE
added config parameter for requires AWS configurations

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,12 +25,12 @@ var services = {};
  Checks if a mock of a method on a service already exists before creating it
 */
 
-AWS.mock = function(service, method, replace) {
+AWS.mock = function(service, method, replace, config) {
   if (!services[service]) {
     services[service]             = {};
     services[service].Constructor = _AWS[service];
     services[service].methodMocks = []
-    mockService(service, method, replace);
+    mockService(service, method, replace, config);
   } else {
     var methodMockExists = services[service].methodMocks.indexOf(method) > -1;
     if (!methodMockExists) {
@@ -49,8 +49,8 @@ AWS.mock = function(service, method, replace) {
 
   Saves the stub to the services object so it can be restored after the test
 */
-function mockService(service, method, replace) {
-  var client               = new services[service].Constructor();
+function mockService(service, method, replace, config) {
+  var client               = new services[service].Constructor(config);
   client.sandbox           = sinon.sandbox.create();
   services[service].client = client;
   mockServiceMethod(service, method, replace);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-sdk-mock",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Functions to mock the JavaScript aws-sdk ",
   "main": "index.js",
   "scripts": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -116,5 +116,17 @@ test('AWS.mock function should mock AWS service and method on the service', func
     st.equals(dynamoDb.putItem.hasOwnProperty('isSinonProxy'), false);
     st.end();
   })
+  t.test('should mock services with required configurations', function(st){
+    awsMock.mock('CloudSearchDomain', 'search', 'searchString', {
+      endpoint: 'mockEndpoint'
+    });
+    var csd = new AWS.CloudSearchDomain();
+
+    csd.search({}, function (err, data) {
+      st.equals(data, 'searchString');
+      awsMock.restore('CloudSearchDomain');
+      st.end();
+    });
+  })
   t.end();
 });


### PR DESCRIPTION
This will fix the issue: https://github.com/dwyl/aws-sdk-mock/issues/12

When some AWS configurations is required, we can add it to the mock:

`awsMock.mock('CloudSearchDomain', 'search', null, {
  endpoint: 'mockEndpoint'
});`