### PR TITLE
Added ability to mock nested services

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,34 @@ exports.handler = function(event, context) {
 }
 ```
 
+### Nested services
+
+It is possible to mock nested services like `DynamoDB.DocumentClient`. Simply use this dot-notation name as the `service` parameter to the `mock()` and `restore()` methods:
+
+```
+AWS.mock('DynamoDB.DocumentClient', 'get', function(params, callback) {
+  callback(null, {Item: {Key: 'Value'}});
+});
+```
+
+**NB: Use caution when mocking both a nested service and its parent service.** The nested service should be mocked before and restored after its parent:
+
+```
+// OK
+AWS.mock('DynamoDB.DocumentClient', 'get', 'message');
+AWS.mock('DynamoDB', 'describeTable', 'message');
+AWS.restore('DynamoDB');
+AWS.restore('DynamoDB.DocumentClient');
+
+// Not OK
+AWS.mock('DynamoDB', 'describeTable', 'message');
+AWS.mock('DynamoDB.DocumentClient', 'get', 'message');
+
+// Not OK
+AWS.restore('DynamoDB.DocumentClient');
+AWS.restore('DynamoDB');
+```
+
 ### Don't worry about the constructor configuration
 Some constructors of the aws-sdk will require you to pass through a configuration object.
 

--- a/package.json
+++ b/package.json
@@ -26,15 +26,15 @@
     "Node.js"
   ],
   "author": "Nikhila Ravi & Jimmy Ruts",
-  "license": "ISC",
+  "license": "GPL-2.0",
   "bugs": {
     "url": "https://github.com/dwyl/aws-sdk-mock/issues"
   },
-  "license": "GPL-2.0",
   "homepage": "https://github.com/dwyl/aws-sdk-mock#readme",
   "dependencies": {
     "aws-sdk": "^2.2.33",
-    "sinon": "^1.17.3"
+    "sinon": "^1.17.3",
+    "traverse": "^0.6.6"
   },
   "devDependencies": {
     "istanbul": "^0.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-sdk-mock",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Functions to mock the JavaScript aws-sdk ",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Addresses issue #16 so nested services can now be mocked with dot notation. The catch is that a nested service must be mocked before and restored after its parent (although you shouldn't be doing this in the first place):

```
// OK
awsMock.mock('DynamoDB.DocumentClient', 'get', 'message');
awsMock.mock('DynamoDB', 'getItem', 'message');
awsMock.restore('DynamoDB');
awsMock.restore('DynamoDB.DocumentClient');

// Not OK
awsMock.mock('DynamoDB', 'getItem', 'message');
awsMock.mock('DynamoDB.DocumentClient', 'get', 'message');

// Not OK
awsMock.restore('DynamoDB.DocumentClient');
awsMock.restore('DynamoDB');
```