### PR TITLE
Small change allowing the replace function to accept any number of arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,13 +83,14 @@ function mockService(service) {
  *  - callback: of the form 'function(err, data) {}'.
  */
 function mockServiceMethod(service, client, method, replace) {
-  services[service].methodMocks[method].stub = sinon.stub(client, method, function(params, callback) {
+  services[service].methodMocks[method].stub = sinon.stub(client, method, function() {
     // If the value of 'replace' is a function we call it with the arguments.
     if(typeof(replace) === 'function') {
-      return replace(params, callback);
+      return replace.apply(replace, arguments);
     }
     // Else we call the callback with the value of 'replace'.
     else {
+      var callback = arguments[arguments.length - 1];
       return callback(null, replace);
     }
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-sdk-mock",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Functions to mock the JavaScript aws-sdk ",
   "main": "index.js",
   "scripts": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -23,6 +23,21 @@ test('AWS.mock function should mock AWS service and method on the service', func
       st.end();
     })
   })
+  t.test('method which accepts any number of arguments can be mocked', function(st) {
+    awsMock.mock('S3', 'getSignedUrl', 'message');
+    var s3 = new AWS.S3();
+    s3.getSignedUrl('getObject', {}, function(err, data) {
+      st.equals(data, 'message');
+      awsMock.mock('S3', 'upload', function(params, options, callback) {
+        callback(null, options);
+      });
+      s3.upload({}, {test: 'message'}, function(err, data) {
+        st.equals(data.test, 'message');
+        awsMock.restore('S3');
+        st.end();
+      });
+    });
+  });
   t.test('method is not re-mocked if a mock already exists', function(st){
     awsMock.mock('SNS', 'publish', function(params, callback){
       callback(null, "message");


### PR DESCRIPTION
Addresses #18. Works as long as all requests to services are asynchronous (i.e. the last parameter of the replacement function is the `(err, data)` callback).