### PR TITLE
Add support for mocking AWS SDK's promises

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ AWS.mock = function(service, method, replace) {
       mockServiceMethod(service, services[service].client, method, replace);
     }
   }
+  return services[service].methodMocks[method];
 }
 
 /**
@@ -87,19 +88,19 @@ function mockServiceMethod(service, client, method, replace) {
     var args = Array.prototype.slice.call(arguments);
 
     // If the method was called w/o a callback function, assume they are consuming a Promise
-    if(typeof(args[args.length - 1]) !== 'function' && typeof(AWS.Promise) === 'function') {
+    if(typeof(args[(args.length || 1) - 1]) !== 'function' && typeof(AWS.Promise) === 'function') {
       return {
         promise: function() {
           return new AWS.Promise(function(resolve, reject) {
             // Provide a callback function for the mock to invoke
             args.push(function(err, val) { return err ? reject(err) : resolve(val) })
-            return invokeMock()
+            return invokeMock();
           })
         }
       }
+    } else {
+      return invokeMock();
     }
-
-    return invokeMock()
 
     function invokeMock() {
       // If the value of 'replace' is a function we call it with the arguments.

--- a/index.js
+++ b/index.js
@@ -98,9 +98,9 @@ function mockServiceMethod(service, client, method, replace) {
         }
       }
     }
-    
+
     return invokeMock()
-    
+
     function invokeMock() {
       // If the value of 'replace' is a function we call it with the arguments.
       if(typeof(replace) === 'function') {
@@ -172,8 +172,10 @@ function restoreMethod(service, method) {
 
 (function(){
   var setPromisesDependency = _AWS.config.setPromisesDependency;
+  /* istanbul ignore next */
+  /* only to support for older versions of aws-sdk */
   if (typeof(setPromisesDependency) === 'function') {
-    AWS.Promise = typeof(Promise) === 'function' ? Promise : null;
+    AWS.Promise = global.Promise
     _AWS.config.setPromisesDependency = function(p) {
       AWS.Promise = p;
       return setPromisesDependency(p);

--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ function mockServiceMethod(service, client, method, replace) {
     var args = Array.prototype.slice.call(arguments);
 
     // If the method was called w/o a callback function, assume they are consuming a Promise
-    if(typeof(AWS.Promise) === 'function' && typeof(args[args.length - 1]) !== 'function') {
+    if(typeof(args[args.length - 1]) !== 'function' && typeof(AWS.Promise) === 'function') {
       return {
         promise: function() {
           return new AWS.Promise(function(resolve, reject) {

--- a/index.js
+++ b/index.js
@@ -44,7 +44,6 @@ AWS.mock = function(service, method, replace) {
       mockServiceMethod(service, services[service].client, method, replace);
     }
   }
-  return services[service].methodMocks[method];
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -84,15 +84,32 @@ function mockService(service) {
  */
 function mockServiceMethod(service, client, method, replace) {
   services[service].methodMocks[method].stub = sinon.stub(client, method, function() {
-    // If the value of 'replace' is a function we call it with the arguments.
-    if(typeof(replace) === 'function') {
-      return replace.apply(replace, arguments);
+    var args = Array.prototype.slice.call(arguments);
+
+    // If the method was called w/o a callback function, assume they are consuming a Promise
+    if(typeof(AWS.Promise) === 'function' && typeof(args[args.length - 1]) !== 'function') {
+      return {
+        promise: function() {
+          return new AWS.Promise(function(resolve, reject) {
+            // Provide a callback function for the mock to invoke
+            args.push(function(err, val) { return err ? reject(err) : resolve(val) })
+            return invokeMock()
+          })
+        }
+      }
     }
-    // Else we call the callback with the value of 'replace'.
-    else {
-      var callback = arguments[arguments.length - 1];
-      return callback(null, replace);
-    }
+
+    return (function invokeMock() {
+      // If the value of 'replace' is a function we call it with the arguments.
+      if(typeof(replace) === 'function') {
+        return replace.apply(replace, args);
+      }
+      // Else we call the callback with the value of 'replace'.
+      else {
+        var callback = args[args.length - 1];
+        return callback(null, replace);
+      }
+    })()
   });
 }
 
@@ -150,5 +167,16 @@ function restoreMethod(service, method) {
   services[service].methodMocks[method].stub.restore();
   delete services[service].methodMocks[method];
 }
+
+(function(){
+  var setPromisesDependency = _AWS.config.setPromisesDependency;
+  if (typeof(setPromisesDependency) === 'function') {
+    AWS.Promise = typeof(Promise) === 'function' ? Promise : null;
+    _AWS.config.setPromisesDependency = function(p) {
+      AWS.Promise = p;
+      return setPromisesDependency(p);
+    };
+  }
+})()
 
 module.exports = AWS;

--- a/index.js
+++ b/index.js
@@ -98,8 +98,10 @@ function mockServiceMethod(service, client, method, replace) {
         }
       }
     }
-
-    return (function invokeMock() {
+    
+    return invokeMock()
+    
+    function invokeMock() {
       // If the value of 'replace' is a function we call it with the arguments.
       if(typeof(replace) === 'function') {
         return replace.apply(replace, args);
@@ -109,7 +111,7 @@ function mockServiceMethod(service, client, method, replace) {
         var callback = args[args.length - 1];
         return callback(null, replace);
       }
-    })()
+    }
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/dwyl/aws-sdk-mock#readme",
   "dependencies": {
-    "aws-sdk": "^2.2.33",
+    "aws-sdk": "^2.3.0",
     "sinon": "^1.17.3",
     "traverse": "^0.6.6"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-sdk-mock",
-  "version": "1.0.10",
+  "version": "1.3.0",
   "description": "Functions to mock the JavaScript aws-sdk ",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
As of March 31, 2016 [the AWS SDK now supports Promises](https://blogs.aws.amazon.com/javascript/post/Tx3BZ2DC4XARUGG/Support-for-Promises-in-the-SDK). This means that you can now do things like this:

```js
var s3 = new AWS.S3({apiVersion: '2006-03-01', region: 'us-west-2'});
var params = {
  Bucket: 'bucket',
  Key: 'example2.txt',
  Body: 'Uploaded text using the promise-based method!'
};
var putObjectPromise = s3.putObject(params).promise();
putObjectPromise.then(function(data) {
  console.log('Success');
}).catch(function(err) {
  console.log(err);
});
```

Attempting to use aws-sdk-mock to mock methods that now no longer require a callback function causes issues, most notably: `TypeError: callback is not a function`. This PR attempts to resolve this issue by checking to see if the mocked method was passed a callback function. If it was passed a callback function then everything should behave exactly as it did before. But if it wasn't then it returns an object containing a single method `promise` which, when invoked, will execute the user's mocked response and the promise will branch based on what the callback returns. It will utilize the native/global promise if available, but it will also pick up on calls to `AWS.config.setPromisesDependency` so that the mocks can create new promises with the provided promise constructor.