### PR TITLE
Adds method to change aws-sdk to be mocked

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,23 @@ Most mocking solutions with throw an `InvalidEndpoint: AWS.CloudSearchDomain req
 **aws-sdk-mock** will take care of this during mock creation so you **won't get any configuration errors**!<br>
 If configurations errors still  occur it means you passed wrong configuration in your implementation.
 
+
+### Setting the `aws-sdk` module explicitly
+
+Project structures that don't include the `aws-sdk` at the top level `node_modules` project folder will not be properly mocked.  An example of this would be installing the `aws-sdk` in a nested project directory. You can get around this by explicitly setting the path to a nested `aws-sdk` module using `setSDK()`.
+
+Example:
+```js
+var path = require('path');
+var AWS = require('aws-sdk-mock');
+
+AWS.setSDK(path.resolve('../../functions/foo/node_modules/aws-sdk'));
+
+/**
+    TESTS
+**/
+```
+
 ## Documentation
 
 ### `AWS.mock(service, method, replace)`
@@ -154,6 +171,16 @@ Removes the mock to restore the specified AWS service
 
 If `AWS.restore` is called without arguments (`AWS.restore()`) then all the services and their associated methods are restored
 i.e. equivalent to a 'restore all' function.
+
+
+### `AWS.setSDK(path)`
+
+Explicitly set the require path for the `aws-sdk`
+
+| Param | Type | Optional/Required | Description     |
+| :------------- | :------------- | :------------- | :------------- |
+| `path`      | string    | Required     | Path to a nested AWS SDK node module     |
+
 
 ## Background Reading
 

--- a/index.js
+++ b/index.js
@@ -18,6 +18,13 @@ var AWS      = {};
 var services = {};
 
 /**
+ * Sets the aws-sdk to be mocked.
+ */
+AWS.setSDK = function(path) {
+  _AWS = require(path);
+};
+
+/**
  * Stubs the service and registers the method that needs to be mocked.
  */
 AWS.mock = function(service, method, replace) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-sdk-mock",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Functions to mock the JavaScript aws-sdk ",
   "main": "index.js",
   "scripts": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -240,3 +240,26 @@ test('AWS.mock function should mock AWS service and method on the service', func
   });
   t.end();
 });
+
+test('AWS.setSDK function should mock a specific AWS module', function(t) {
+  t.test('Specific Modules can be set for mocking', function(st) {
+    awsMock.setSDK('aws-sdk');
+    awsMock.mock('SNS', 'publish', 'message');
+    var sns = new AWS.SNS();
+    sns.publish({}, function(err, data){
+      st.equals(data, 'message');
+      awsMock.restore('SNS');
+      st.end();
+    })
+  });
+
+  t.test('Setting the aws-sdk to the wrong module can cause an exception when mocking', function(st) {
+    awsMock.setSDK('sinon');
+    st.throws(function() {
+      awsMock.mock('SNS', 'publish', 'message')
+    });
+    awsMock.setSDK('aws-sdk');
+    st.end();
+  });
+  t.end();
+});


### PR DESCRIPTION
Had a need, due to our project structure, to be more specific about the `aws-sdk` module to be mocked.  Added a method, `setSDK()`, to allow you to pass in a path to the specific module that you would like to mock.