### PR TITLE
made restoreService more robust

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,7 +157,8 @@ function restoreAllServices() {
 function restoreService(service) {
   if (services[service]) {
     restoreAllMethods(service);
-    services[service].stub.restore();
+    if( services[service].stub)
+      services[service].stub.restore();
     delete services[service];
   } else {
     console.log('Service ' + service + ' was never instantiated yet you try to restore it.');


### PR DESCRIPTION
In case you call restore twice in a test framework this may fail with "TypeError: Cannot read property 'restore' of undefined"

see my boilerplate here:

https://github.com/H34D/mock-off
