### PR TITLE
Add minimal createReadStream support

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,11 +137,11 @@ function mockServiceMethod(service, client, method, replace) {
         return promise;
       } : undefined,
       createReadStream: function() {
-        return new Readable({
-          read: function(size) {
-            this.push(null);
-          }
-        });
+        var stream = new Readable();
+        stream._read = function(size) {
+          this.push(null);
+        };
+        return stream;
       }
     };
     // If the value of 'replace' is a function we call it with the arguments.

--- a/index.js
+++ b/index.js
@@ -127,9 +127,9 @@ function mockServiceMethod(service, client, method, replace) {
       }
     };
     var request = {
-      promise: (typeof(AWS.Promise) === 'function') ? function() {
+      promise: havePromises ? function() {
         if (!promise) {
-          promise = new Promise(function (resolve_, reject_) {
+          promise = new AWS.Promise(function (resolve_, reject_) {
             resolve = resolve_;
             reject = reject_;
           });

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@
 var sinon = require('sinon');
 var traverse = require('traverse');
 var _AWS  = require('aws-sdk');
+var Readable = require('stream').Readable;
 
 var AWS      = {};
 var services = {};
@@ -94,32 +95,64 @@ function mockServiceMethod(service, client, method, replace) {
   services[service].methodMocks[method].stub = sinon.stub(client, method, function() {
     var args = Array.prototype.slice.call(arguments);
 
-    // If the method was called w/o a callback function, assume they are consuming a Promise
-    if(typeof(args[(args.length || 1) - 1]) !== 'function' && typeof(AWS.Promise) === 'function') {
-      return {
-        promise: function() {
-          return new AWS.Promise(function(resolve, reject) {
-            // Provide a callback function for the mock to invoke
-            args.push(function(err, val) { return err ? reject(err) : resolve(val) })
-            return invokeMock();
-          })
+    var userArgs, userCallback;
+    if (typeof(args[(args.length || 1) - 1]) === 'function') {
+      userArgs = args.slice(0, -1);
+      userCallback = args[(args.length || 1) - 1];
+    } else {
+      userArgs = args;
+    }
+    var havePromises = typeof(AWS.Promise) === 'function';
+    var promise, resolve, reject;
+    var makeResolved = function(value) {return new AWS.Promise(function (res) { res(value); }); };
+    var makeRejected = function(value) {return new AWS.Promise(function (res, rej) { rej(value); }); };
+    var callback = function(err, data) {
+      if (havePromises) {
+        if (err) {
+          if (reject) {
+            reject(err);
+          } else {
+            promise = makeRejected(err);
+          }
+        } else {
+          if (resolve) {
+            resolve(data);
+          } else {
+            promise = makeResolved(data);
+          }
         }
       }
-    } else {
-      return invokeMock();
-    }
-
-    function invokeMock() {
-      // If the value of 'replace' is a function we call it with the arguments.
-      if(typeof(replace) === 'function') {
-        return replace.apply(replace, args);
+      if (userCallback) {
+        userCallback(err, data);
       }
-      // Else we call the callback with the value of 'replace'.
-      else {
-        var callback = args[args.length - 1];
-        return callback(null, replace);
+    };
+    var request = {
+      promise: (typeof(AWS.Promise) === 'function') ? function() {
+        if (!promise) {
+          promise = new Promise(function (resolve_, reject_) {
+            resolve = resolve_;
+            reject = reject_;
+          });
+        }
+        return promise;
+      } : undefined,
+      createReadStream: function() {
+        return new Readable({
+          read: function(size) {
+            this.push(null);
+          }
+        });
       }
+    };
+    // If the value of 'replace' is a function we call it with the arguments.
+    if(typeof(replace) === 'function') {
+      replace.apply(replace, userArgs.concat([callback]));
     }
+    // Else we call the callback with the value of 'replace'.
+    else {
+      callback(null, replace);
+    }
+    return request;
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "traverse": "^0.6.6"
   },
   "devDependencies": {
+    "is-node-stream": "^1.0.0",
     "istanbul": "^0.4.2",
     "tape": "^4.4.0"
   }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "is-node-stream": "^1.0.0",
     "istanbul": "^0.4.2",
+    "stream-to-array": "^2.3.0",
     "tape": "^4.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
     "traverse": "^0.6.6"
   },
   "devDependencies": {
+    "concat-stream": "^1.5.1",
     "is-node-stream": "^1.0.0",
     "istanbul": "^0.4.2",
-    "stream-to-array": "^2.3.0",
     "tape": "^4.4.0"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,7 +2,7 @@ var test     = require('tape');
 var awsMock = require('../index.js');
 var AWS      = require('aws-sdk');
 var isNodeStream = require('is-node-stream');
-var streamToArray = require('stream-to-array');
+var concatStream = require('concat-stream');
 
 test('AWS.mock function should mock AWS service and method on the service', function(t){
   t.test('mock function replaces method with a function that returns replace string', function(st){
@@ -160,9 +160,9 @@ test('AWS.mock function should mock AWS service and method on the service', func
     // let's just consume it and ignore the contents
     req = s3.getObject('getObject', {});
     var stream = req.createReadStream();
-    streamToArray(stream, function() {
+    stream.pipe(concatStream(function() {
       st.end();
-    });
+    }));
   });
   t.test('all the methods on a service are restored', function(st){
     awsMock.mock('SNS', 'publish', function(params, callback){

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,6 +1,7 @@
 var test     = require('tape');
 var awsMock = require('../index.js');
 var AWS      = require('aws-sdk');
+var isNodeStream = require('is-node-stream');
 
 test('AWS.mock function should mock AWS service and method on the service', function(t){
   t.test('mock function replaces method with a function that returns replace string', function(st){
@@ -126,6 +127,16 @@ test('AWS.mock function should mock AWS service and method on the service', func
       });
     })
   }
+  t.test('request object supports createReadStream', function(st) {
+    awsMock.mock('S3', 'getObject', 'body');
+    var s3 = new AWS.S3();
+    var req = s3.getObject('getObject', {}, function(err, data) {});
+    st.ok(isNodeStream(req.createReadStream()));
+    // with or without callback
+    req = s3.getObject('getObject', {});
+    st.ok(isNodeStream(req.createReadStream()));
+    st.end();
+  });
   t.test('all the methods on a service are restored', function(st){
     awsMock.mock('SNS', 'publish', function(params, callback){
       callback(null, "message");

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,6 +2,7 @@ var test     = require('tape');
 var awsMock = require('../index.js');
 var AWS      = require('aws-sdk');
 var isNodeStream = require('is-node-stream');
+var streamToArray = require('stream-to-array');
 
 test('AWS.mock function should mock AWS service and method on the service', function(t){
   t.test('mock function replaces method with a function that returns replace string', function(st){
@@ -104,6 +105,26 @@ test('AWS.mock function should mock AWS service and method on the service', func
         st.end();
       });
     })
+    t.test('promises work with async completion', function(st){
+      awsMock.restore('Lambda', 'getFunction');
+      awsMock.restore('Lambda', 'createFunction');
+      var error = new Error('on purpose');
+      awsMock.mock('Lambda', 'getFunction', function(params, callback) {
+        setTimeout(callback.bind(this, null, 'message'), 10);
+      });
+      awsMock.mock('Lambda', 'createFunction', function(params, callback) {
+        setTimeout(callback.bind(this, error, 'message'), 10);
+      });
+      var lambda = new AWS.Lambda();
+      lambda.getFunction({}).promise().then(function(data) {
+        st.equals(data, 'message');
+      }).then(function(){
+        return lambda.createFunction({}).promise()
+      }).catch(function(data){
+        st.equals(data, error);
+        st.end();
+      });
+    })
     t.test('promises can be configured', function(st){
       awsMock.restore('Lambda', 'getFunction');
       awsMock.mock('Lambda', 'getFunction', function(params, callback) {
@@ -135,7 +156,13 @@ test('AWS.mock function should mock AWS service and method on the service', func
     // with or without callback
     req = s3.getObject('getObject', {});
     st.ok(isNodeStream(req.createReadStream()));
-    st.end();
+    // stream is currently always empty but that's subject to change.
+    // let's just consume it and ignore the contents
+    req = s3.getObject('getObject', {});
+    var stream = req.createReadStream();
+    streamToArray(stream, function() {
+      st.end();
+    });
   });
   t.test('all the methods on a service are restored', function(st){
     awsMock.mock('SNS', 'publish', function(params, callback){


### PR DESCRIPTION
This is my implementation of #39. I tried to somewhat harmonize the callback, Promise and stream code paths, while keeping all the previously supported use cases.