### PR TITLE
Feature proposal: Validate service method params if config.paramValidation is set

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,6 +144,19 @@ function mockServiceMethod(service, client, method, replace) {
         return stream;
       }
     };
+
+    if ((client.config || _AWS.config).paramValidation) {
+      try {
+        var inputRules = client.api.operations[method].input;
+        var outputRules = client.api.operations[method].output;
+        var params = userArgs[(userArgs.length || 1) - 1];
+        new _AWS.ParamValidator((client.config || _AWS.config).paramValidation).validate(inputRules, params);
+      } catch (e) {
+        callback(e, null);
+        return request;
+      }
+    }
+
     // If the value of 'replace' is a function we call it with the arguments.
     if(typeof(replace) === 'function') {
       replace.apply(replace, userArgs.concat([callback]));


### PR DESCRIPTION
This reuses the SDK's own validation code, and is technically a breaking change: Since the default for `AWS.config.paramValidation` is `true`, currently-passing tests may break if they rely on invalid AWS calls succeeding.

I initially started down the route of making all of `aws-sdk-mock`'s own tests use valid AWS input data, but quickly realized it was impractical. So I just set `paramValidation=false` globally and enabled it for the new tests only.

In my own project I do something similar for outputs, too, essentially checking that my mocks are realistic. However, this has no analog in `aws-sdk` and I'm not sure what would be the optimal way to do something similar in this module.