### PR TITLE
feat: setSDKInstance to allow mocking of specific aws objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,26 @@ AWS.setSDK(path.resolve('../../functions/foo/node_modules/aws-sdk'));
 **/
 ```
 
+### Setting the `aws-sdk` object explicitly
+
+Due to transpiling, code written in TypeScript or ES6 may not correctly mock because the `aws-sdk` object created within `aws-sdk-mock` will not be equal to the object created within the code to test. In addition, it is sometimes convenient to have multiple SDK instances in a test. For either scenario, it is possible to pass in the SDK object directly using `setSDKInstance()`.
+
+Example:
+```js
+var path = require('path');
+var AWS = require('aws-sdk-mock');
+var AWS_SDK = require('aws-sdk')
+
+AWS.setSDKInstance(AWS_SDK);
+
+/**
+    TESTS
+**/
+```
+
+
+
+
 ## Documentation
 
 ### `AWS.mock(service, method, replace)`
@@ -180,6 +200,15 @@ Explicitly set the require path for the `aws-sdk`
 | Param | Type | Optional/Required | Description     |
 | :------------- | :------------- | :------------- | :------------- |
 | `path`      | string    | Required     | Path to a nested AWS SDK node module     |
+
+### `AWS.setSDKInstance(sdk)`
+
+Explicitly set the `aws-sdk` instance to use
+
+| Param | Type | Optional/Required | Description     |
+| :------------- | :------------- | :------------- | :------------- |
+| `sdk`      | object    | Required     | The AWS SDK object     |
+
 
 
 ## Background Reading

--- a/index.js
+++ b/index.js
@@ -25,6 +25,10 @@ AWS.setSDK = function(path) {
   _AWS = require(path);
 };
 
+AWS.setSDKInstance = function(sdk) {
+  _AWS = sdk
+}
+
 /**
  * Stubs the service and registers the method that needs to be mocked.
  */

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -373,7 +373,36 @@ test('AWS.setSDK function should mock a specific AWS module', function(t) {
       awsMock.mock('SNS', 'publish', 'message')
     });
     awsMock.setSDK('aws-sdk');
+    awsMock.restore()
+
     st.end();
   });
   t.end();
 });
+
+test('AWS.setSDKInstance function should mock a specific AWS module', function(t) {
+  t.test('Specific Modules can be set for mocking', function(st) {
+    var aws2 = require('aws-sdk')
+    awsMock.setSDKInstance(aws2);
+    awsMock.mock('SNS', 'publish', 'message2');
+    var sns = new AWS.SNS();
+    sns.publish({}, function(err, data){
+      st.equals(data, 'message2');
+      awsMock.restore('SNS');
+      st.end();
+    })
+  });
+
+  t.test('Setting the aws-sdk to the wrong instance can cause an exception when mocking', function(st) {
+    var bad = {}
+    awsMock.setSDKInstance(bad);
+    st.throws(function() {
+      awsMock.mock('SNS', 'publish', 'message')
+    });
+    awsMock.setSDKInstance(AWS);
+    awsMock.restore()
+    st.end();
+  });
+  t.end();
+});
+


### PR DESCRIPTION
Hey, thanks for making this awesome library.

Sometimes due to transpiling (both in TypeScript and Babel) require('aws-sdk') will actually point to different objects when called outside of the aws-sdk-mock file.

The most straightforward way I've figured out how to deal with this is to add a function that allows the test to pass in the instance it is using. 
