### PR TITLE
Add createReadStream payload support

### DIFF
--- a/index.js
+++ b/index.js
@@ -139,6 +139,9 @@ function mockServiceMethod(service, client, method, replace) {
       createReadStream: function() {
         var stream = new Readable();
         stream._read = function(size) {
+          if(typeof(replace) === 'string' || Buffer.isBuffer(replace)) {
+            this.push(replace);
+          }
           this.push(null);
         };
         return stream;


### PR DESCRIPTION
I have a scenario where I need to test S3 streams. This feature would save me a lot of trouble.
