### PR TITLE
fix(paramValidation): skip param validation when method has no input rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,10 +150,11 @@ function mockServiceMethod(service, client, method, replace) {
 
     if ((client.config || _AWS.config).paramValidation) {
       try {
-        var inputRules = client.api.operations[method].input;
-        var outputRules = client.api.operations[method].output;
-        var params = userArgs[(userArgs.length || 1) - 1];
-        new _AWS.ParamValidator((client.config || _AWS.config).paramValidation).validate(inputRules, params);
+        var inputRules = (client.api.operations[method] || {}).input;
+        if (inputRules) {
+          var params = userArgs[(userArgs.length || 1) - 1];
+          new _AWS.ParamValidator((client.config || _AWS.config).paramValidation).validate(inputRules, params);
+        }
       } catch (e) {
         callback(e, null);
         return request;

--- a/index.js
+++ b/index.js
@@ -148,9 +148,13 @@ function mockServiceMethod(service, client, method, replace) {
       }
     };
 
-    if ((client.config || _AWS.config).paramValidation) {
+    // different locations for the paramValidation property
+    var config = (client.config || client.options || _AWS.config);
+    if (config.paramValidation) {
       try {
-        var inputRules = (client.api.operations[method] || {}).input;
+        // different strategies to find method, depending on wether the service is nested/unnested
+        var inputRules =
+          ((client.api && client.api.operations[method]) || client[method] || {}).input;
         if (inputRules) {
           var params = userArgs[(userArgs.length || 1) - 1];
           new _AWS.ParamValidator((client.config || _AWS.config).paramValidation).validate(inputRules, params);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -52,6 +52,15 @@ test('AWS.mock function should mock AWS service and method on the service', func
       st.end();
     });
   });
+  t.test('method with no input rules can be mocked even if paramValidation is set', function(st) {
+    awsMock.mock('S3', 'getSignedUrl', 'message');
+    var s3 = new AWS.S3({paramValidation: true});
+    s3.getSignedUrl('getObject', {}, function(err, data) {
+      st.equals(data, 'message');
+      awsMock.restore('S3');
+      st.end();
+    });
+  });
   t.test('method succeeds on valid input when paramValidation is set', function(st) {
     awsMock.mock('S3', 'getObject', {Body: 'body'});
     var s3 = new AWS.S3({paramValidation: true});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -327,6 +327,21 @@ test('AWS.mock function should mock AWS service and method on the service', func
       });
     })
   });
+  t.test('a nested service can be mocked properly even when paramValidation is set', function(st){
+    awsMock.mock('DynamoDB.DocumentClient', 'query', function(params, callback) {
+      callback(null, 'test');
+    });
+    var docClient = new AWS.DynamoDB.DocumentClient({paramValidation: true});
+
+    st.equals(AWS.DynamoDB.DocumentClient.isSinonProxy, true);
+    st.equals(docClient.query.isSinonProxy, true);
+    docClient.query({}, function(err, data){
+      console.warn(err);
+      st.equals(data, 'test');
+      awsMock.restore('DynamoDB.DocumentClient', 'query');
+      st.end();
+    })
+  });
   t.test('a mocked service and a mocked nested service can coexist as long as the nested service is mocked first', function(st) {
     awsMock.mock('DynamoDB.DocumentClient', 'get', 'message');
     awsMock.mock('DynamoDB', 'getItem', 'test');


### PR DESCRIPTION
This PR fixes the following error:

`TypeError: Cannot read property 'input' of undefined`

When trying to create mocks like this with `paramValidation: true`:
```
      AWS.mock('S3', 'getSignedUrl', (fnName, params, callback) => {
        const s3url = `https://s3.amazonaws.com/${params.Bucket}/${params.Key}`;
        callback(null, `${s3url}?${signatureParams}`);
      });
```