### PR TITLE
Add `on` method to request object

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,6 +150,8 @@ function mockServiceMethod(service, client, method, replace) {
           this.push(null);
         };
         return stream;
+      },
+      on: function(eventName, callback) {
       }
     };
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -252,6 +252,13 @@ test('AWS.mock function should mock AWS service and method on the service', func
       st.end();
     }));
   });
+  t.test('call on method of request object', function(st) {
+    awsMock.mock('S3', 'getObject', {Body: 'body'});
+    var s3 = new AWS.S3();
+    var req = s3.getObject('getObject', {});
+    st.equals(typeof req.on, 'function');
+    st.end();
+  });
   t.test('all the methods on a service are restored', function(st){
     awsMock.mock('SNS', 'publish', function(params, callback){
       callback(null, "message");


### PR DESCRIPTION
Since there was no on method and the following error occurred
```
TypeError: request.on is not a function
```

Reference:
http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Request.html

If you better open the issue first, I will do so, please point out.

fixies: #135