### PR TITLE
Fix "Why" header in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ https://github.com/dwyl/learn-aws-lambda
 * [Documentation](#documentation)
 * [Background Reading](#background-reading)
 
-## Why?
+## Why?
 
 Testing your code is *essential* everywhere you need *reliability*.
 


### PR DESCRIPTION
Seems like some invisible character was preventing the header from rendering correctly on Github.