### PR TITLE
allow spy to return promise rather than call callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,7 +110,9 @@ function mockServiceMethod(service, client, method, replace) {
     var promise, resolve, reject, storedResult;
     var tryResolveFromStored = function() {
       if (storedResult && promise) {
-        if (storedResult.reject) {
+        if (typeof storedResult.then === 'function') {
+          storedResult.then(resolve, reject)
+        } else if (storedResult.reject) {
           reject(storedResult.reject);
         } else {
           resolve(storedResult.resolve);
@@ -172,7 +174,11 @@ function mockServiceMethod(service, client, method, replace) {
 
     // If the value of 'replace' is a function we call it with the arguments.
     if(typeof(replace) === 'function') {
-      replace.apply(replace, userArgs.concat([callback]));
+      var result = replace.apply(replace, userArgs.concat([callback]));
+      if (storedResult === undefined && result != null &&
+          typeof result.then === 'function') {
+        storedResult = result
+      }
     }
     // Else we call the callback with the value of 'replace'.
     else {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -136,6 +136,26 @@ test('AWS.mock function should mock AWS service and method on the service', func
         st.end();
       });
     });
+    t.test('replacement returns thennable', function(st){
+      awsMock.restore('Lambda', 'getFunction');
+      awsMock.restore('Lambda', 'createFunction');
+      var error = new Error('on purpose');
+      awsMock.mock('Lambda', 'getFunction', function(params) {
+        return Promise.resolve('message')
+      });
+      awsMock.mock('Lambda', 'createFunction', function(params, callback) {
+        return Promise.reject(error)
+      });
+      var lambda = new AWS.Lambda();
+      lambda.getFunction({}).promise().then(function(data) {
+        st.equals(data, 'message');
+      }).then(function(){
+        return lambda.createFunction({}).promise();
+      }).catch(function(data){
+        st.equals(data, error);
+        st.end();
+      });
+    });
     t.test('no unhandled promise rejections when promises are not used', function(st) {
       process.on('unhandledRejection', function(reason, promise) {
         st.fail('unhandledRejection, reason follows');


### PR DESCRIPTION
This patch allows a replacement function (e.g. a spy) to return a promise rather than call the callback, which is (IMO) a little more natural when using promises everywhere else.

Ref: https://github.com/dwyl/aws-sdk-mock/issues/113

A test has been added.