### PR TITLE
Upgrade to sinon 4.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - 0.10.36
   - "4.2.3"
+  - "node"
 before_install:
   - pip install --user codecov
 after_success:

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ function mockService(service) {
   var method = nestedServices.pop();
   var object = traverse(_AWS).get(nestedServices);
 
-  var serviceStub = sinon.stub(object, method, function(args) {
+  var serviceStub = sinon.stub(object, method).callsFake(function(args) {
     services[service].invoked = true;
 
     /**
@@ -96,7 +96,7 @@ function mockService(service) {
  *  - callback: of the form 'function(err, data) {}'.
  */
 function mockServiceMethod(service, client, method, replace) {
-  services[service].methodMocks[method].stub = sinon.stub(client, method, function() {
+  services[service].methodMocks[method].stub = sinon.stub(client, method).callsFake(function() {
     var args = Array.prototype.slice.call(arguments);
 
     var userArgs, userCallback;

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/dwyl/aws-sdk-mock#readme",
   "dependencies": {
     "aws-sdk": "^2.3.0",
-    "sinon": "^1.17.3",
+    "sinon": "^4.5.0",
     "traverse": "^0.6.6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   "homepage": "https://github.com/dwyl/aws-sdk-mock#readme",
   "dependencies": {
     "aws-sdk": "^2.3.0",
-    "sinon": "^4.5.0",
-    "traverse": "^0.6.6"
+    "traverse": "^0.6.6",
+    "sinon": "^4.5.0"
   },
   "devDependencies": {
     "concat-stream": "^1.5.1",


### PR DESCRIPTION
This pull requests upgrades to a much newer version of sinon (4.5.0) which enables a much broader spy assertion API than v1