### PR TITLE
Replace istanbul by nyc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 coverage/
 .DS_Store
+.nyc_output

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "nocov": "tape test/*.js",
-    "test": "istanbul cover ./node_modules/tape/bin/tape ./test/*.js",
-    "coverage": "istanbul cover ./node_modules/tape/bin/tape ./test/*.js && istanbul check-coverage --statements 100 --functions 100 --lines 100 --branches 100 --report html"
+    "test": "nyc --reporter=lcov tape ./test/*.js",
+    "coverage": "nyc tape ./test/*.js && nyc check-coverage --statements 100 --functions 100 --lines 100 --branches 100 --report html"
   },
   "repository": {
     "type": "git",
@@ -39,7 +39,7 @@
   "devDependencies": {
     "concat-stream": "^1.5.1",
     "is-node-stream": "^1.0.0",
-    "istanbul": "^0.4.2",
+    "nyc": "^12.0.2",
     "tape": "^4.4.0"
   }
 }


### PR DESCRIPTION
Current version of `istanbul` has been deprecated. `nyc` is the "go to" replacement tool.