### PR TITLE
Add testing on more node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: node_js
 node_js:
-  - "4.2.3"
-  - "node"
+  - "4"
+  - "6"
+  - "8"
+  - "10"
 before_install:
   - pip install --user codecov
 after_success:


### PR DESCRIPTION
Just to make sure that the lib is usable on every LTS node version. I did not remove version 4 but I guess we could.