### PR TITLE
support passing a Readable stream as the stub for S3.GetObject

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ AWS.mock('DynamoDB', 'putItem', function (params, callback){
 
 AWS.mock('SNS', 'publish', 'test-message');
 
-// S3 getObject mock - return a Bffer object with file data
+// S3 getObject mock - return a Buffer object with file data
 awsMock.mock("S3", "getObject", Buffer.from(require("fs").readFileSync("testFile.csv")));
 
 

--- a/index.js
+++ b/index.js
@@ -144,14 +144,18 @@ function mockServiceMethod(service, client, method, replace) {
         return promise;
       } : undefined,
       createReadStream: function() {
-        var stream = new Readable();
-        stream._read = function(size) {
-          if(typeof(replace) === 'string' || Buffer.isBuffer(replace)) {
-            this.push(replace);
-          }
-          this.push(null);
-        };
-        return stream;
+        if (replace instanceof Readable) {
+          return replace;
+        } else {
+          var stream = new Readable();
+          stream._read = function(size) {
+            if(typeof(replace) === 'string' || Buffer.isBuffer(replace)) {
+              this.push(replace);
+            }
+            this.push(null);
+          };
+          return stream;
+        }
       },
       on: function(eventName, callback) {
       },

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "index.js"
   ],
   "scripts": {
-    "nocov": "tape test/*.js",
-    "test": "nyc --reporter=lcov tape ./test/*.js",
-    "coverage": "nyc tape ./test/*.js && nyc check-coverage --statements 100 --functions 100 --lines 100 --branches 100 --report html"
+    "nocov": "tap test/*.js",
+    "test": "nyc --reporter=lcov tap ./test/*.js",
+    "coverage": "nyc tap ./test/*.js && nyc check-coverage --statements 100 --functions 100 --lines 100 --branches 100 --report html"
   },
   "repository": {
     "type": "git",
@@ -43,6 +43,6 @@
     "concat-stream": "^1.6.2",
     "is-node-stream": "^1.0.0",
     "nyc": "^12.0.2",
-    "tape": "^4.9.1"
+    "tap": "^12.0.1"
   }
 }


### PR DESCRIPTION
- swapped tape with tap to get afterEach, so that the sandbox can be
  predictably restored after each test.
  - removed all restore calls that do not test restore feature
- skipped the test about a stub being returned because that behavior
  only applies when the service constructor has already been called when
  mock is called. the test previously passed due to side effects of
  unrestored sandbox.

fixes  #142