### PR TITLE
allow remocking with new values

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ AWS.Promise = Q.Promise;
 
 ## Documentation
 
-### `AWS.mock(service, method, replace, update)`
+### `AWS.mock(service, method, replace)`
 
 Replaces a method on an AWS service with a replacement function or string.
 
@@ -242,7 +242,6 @@ Replaces a method on an AWS service with a replacement function or string.
 | `service`      | string    | Required     | AWS service to mock e.g. SNS, DynamoDB, S3     |
 | `method`      | string    | Required     | method on AWS service to mock e.g. 'publish' (for SNS), 'putItem' for 'DynamoDB'     |
 | `replace`      | string or function    | Required     | A string or function to replace the method   |
-| `update`      | boolean    | Optional     | Should the `replace` method be updated if it already exists? `true` updates the `replace` value  |
 
 
 ### `AWS.restore(service, method)`
@@ -256,6 +255,18 @@ Removes the mock to restore the specified AWS service
 
 If `AWS.restore` is called without arguments (`AWS.restore()`) then all the services and their associated methods are restored
 i.e. equivalent to a 'restore all' function.
+
+
+### `AWS.remock(service, method, replace)`
+
+Updates the `replace` method on an existing mocked service.
+
+
+| Param | Type | Optional/Required | Description     |
+| :------------- | :------------- | :------------- | :------------- |
+| `service`      | string    | Required     | AWS service to mock e.g. SNS, DynamoDB, S3     |
+| `method`      | string    | Required     | method on AWS service to mock e.g. 'publish' (for SNS), 'putItem' for 'DynamoDB'     |
+| `replace`      | string or function    | Required     | A string or function to replace the method   |
 
 
 ### `AWS.setSDK(path)`

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ AWS.Promise = Q.Promise;
 
 ## Documentation
 
-### `AWS.mock(service, method, replace)`
+### `AWS.mock(service, method, replace, update)`
 
 Replaces a method on an AWS service with a replacement function or string.
 
@@ -242,6 +242,7 @@ Replaces a method on an AWS service with a replacement function or string.
 | `service`      | string    | Required     | AWS service to mock e.g. SNS, DynamoDB, S3     |
 | `method`      | string    | Required     | method on AWS service to mock e.g. 'publish' (for SNS), 'putItem' for 'DynamoDB'     |
 | `replace`      | string or function    | Required     | A string or function to replace the method   |
+| `update`      | boolean    | Optional     | Should the `replace` method be updated if it already exists? `true` updates the `replace` value  |
 
 
 ### `AWS.restore(service, method)`

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ AWS.setSDKInstance = function(sdk) {
 /**
  * Stubs the service and registers the method that needs to be mocked.
  */
-AWS.mock = function(service, method, replace, update) {
+AWS.mock = function(service, method, replace) {
   // If the service does not exist yet, we need to create and stub it.
   if (!services[service]) {
     services[service]             = {};
@@ -57,18 +57,27 @@ AWS.mock = function(service, method, replace, update) {
     }
   }
 
-  if (update) {
-    if (services[service].methodMocks[method]) {
-      restoreMethod(service, method);
-      services[service].methodMocks[method] = { replace: replace };
-    }
-    if(services[service].invoked) {
-      mockServiceMethod(service, services[service].client, method, replace);
-    }
+  return services[service].methodMocks[method];
+};
+
+/**
+ * Stubs the service and registers the method that needs to be re-mocked.
+ */
+AWS.remock = function(service, method, replace) {
+
+  if (services[service].methodMocks[method]) {
+    restoreMethod(service, method);
+    services[service].methodMocks[method] = {
+      replace: replace
+    };
+  }
+
+  if (services[service].invoked) {
+    mockServiceMethod(service, services[service].client, method, replace);
   }
 
   return services[service].methodMocks[method];
-};
+}
 
 /**
  * Stub the constructor for the service on AWS.

--- a/index.js
+++ b/index.js
@@ -62,8 +62,11 @@ AWS.mock = function(service, method, replace, update) {
       restoreMethod(service, method);
       services[service].methodMocks[method] = { replace: replace };
     }
+    if(services[service].invoked) {
+      mockServiceMethod(service, services[service].client, method, replace);
+    }
   }
-  
+
   return services[service].methodMocks[method];
 };
 

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ AWS.setSDKInstance = function(sdk) {
 /**
  * Stubs the service and registers the method that needs to be mocked.
  */
-AWS.mock = function(service, method, replace) {
+AWS.mock = function(service, method, replace, update) {
   // If the service does not exist yet, we need to create and stub it.
   if (!services[service]) {
     services[service]             = {};
@@ -48,17 +48,22 @@ AWS.mock = function(service, method, replace) {
   }
 
   // Register the method to be mocked out.
-  if (services[service].methodMocks[method]) {
-    restoreMethod(service, method);
+  if(!services[service].methodMocks[method]) {
+    services[service].methodMocks[method] = { replace: replace };
+
+    // If the constructor was already invoked, we need to mock the method here.
+    if(services[service].invoked) {
+      mockServiceMethod(service, services[service].client, method, replace);
+    }
   }
 
-  services[service].methodMocks[method] = { replace: replace };
-
-  // If the constructor was already invoked, we need to mock the method here.
-  if(services[service].invoked) {
-    mockServiceMethod(service, services[service].client, method, replace);
+  if (update) {
+    if (services[service].methodMocks[method]) {
+      restoreMethod(service, method);
+      services[service].methodMocks[method] = { replace: replace };
+    }
   }
-
+  
   return services[service].methodMocks[method];
 };
 

--- a/index.js
+++ b/index.js
@@ -48,14 +48,17 @@ AWS.mock = function(service, method, replace) {
   }
 
   // Register the method to be mocked out.
-  if(!services[service].methodMocks[method]) {
-    services[service].methodMocks[method] = { replace: replace };
-
-    // If the constructor was already invoked, we need to mock the method here.
-    if(services[service].invoked) {
-      mockServiceMethod(service, services[service].client, method, replace);
-    }
+  if (services[service].methodMocks[method]) {
+    restoreMethod(service, method);
   }
+
+  services[service].methodMocks[method] = { replace: replace };
+
+  // If the constructor was already invoked, we need to mock the method here.
+  if(services[service].invoked) {
+    mockServiceMethod(service, services[service].client, method, replace);
+  }
+
   return services[service].methodMocks[method];
 };
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -98,14 +98,14 @@ test('AWS.mock function should mock AWS service and method on the service', func
       st.end();
     });
   });
-  t.test('service is re-mocked if update flag passed', function(st){
+  t.test('service is re-mocked when remock called', function(st){
     awsMock.mock('SNS', 'subscribe', function(params, callback){
       callback(null, 'message 1');
     });
     var sns = new AWS.SNS();
-    awsMock.mock('SNS', 'subscribe', function(params, callback){
+    awsMock.remock('SNS', 'subscribe', function(params, callback){
       callback(null, 'message 2');
-    }, true);
+    });
     sns.subscribe({}, function(err, data){
       st.equals(data, 'message 2');
       st.end();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -72,7 +72,7 @@ test('AWS.mock function should mock AWS service and method on the service', func
       st.end();
     });
   });
-  t.test('method is re-mocked if a mock already exists', function(st){
+  t.test('method is not re-mocked if a mock already exists', function(st){
     awsMock.mock('SNS', 'publish', function(params, callback){
       callback(null, "message");
     });
@@ -85,7 +85,7 @@ test('AWS.mock function should mock AWS service and method on the service', func
       st.end();
     });
   });
-  t.test('service is re-mocked if a mock already exists', function(st){
+  t.test('service is not re-mocked if a mock already exists', function(st){
     awsMock.mock('SNS', 'publish', function(params, callback){
       callback(null, "message");
     });
@@ -95,6 +95,19 @@ test('AWS.mock function should mock AWS service and method on the service', func
     });
     sns.subscribe({}, function(err, data){
       st.equals(data, 'test');
+      st.end();
+    });
+  });
+  t.test('service is re-mocked if update flag passed', function(st){
+    awsMock.mock('SNS', 'subscribe', function(params, callback){
+      callback(null, 'message 1');
+    });
+    var sns = new AWS.SNS();
+    awsMock.mock('SNS', 'subscribe', function(params, callback){
+      callback(null, 'message 2');
+    }, true);
+    sns.subscribe({}, function(err, data){
+      st.equals(data, 'message 2');
       st.end();
     });
   });
@@ -344,7 +357,7 @@ test('AWS.mock function should mock AWS service and method on the service', func
     awsMock.mock('DynamoDB.DocumentClient', 'put', 'message');
     var docClient = new AWS.DynamoDB.DocumentClient();
     awsMock.mock('DynamoDB.DocumentClient', 'put', function(params, callback) {
-      callback(null, 'puttest');
+      callback(null, 'test');
     });
     awsMock.mock('DynamoDB.DocumentClient', 'get', function(params, callback) {
       callback(null, 'test');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -81,7 +81,7 @@ test('AWS.mock function should mock AWS service and method on the service', func
       callback(null, "test");
     });
     sns.publish({}, function(err, data){
-      st.equals(data, 'test');
+      st.equals(data, 'message');
       st.end();
     });
   });
@@ -347,7 +347,7 @@ test('AWS.mock function should mock AWS service and method on the service', func
       callback(null, 'puttest');
     });
     awsMock.mock('DynamoDB.DocumentClient', 'get', function(params, callback) {
-      callback(null, 'gettest');
+      callback(null, 'test');
     });
 
     st.equals(AWS.DynamoDB.DocumentClient.isSinonProxy, true);
@@ -355,9 +355,9 @@ test('AWS.mock function should mock AWS service and method on the service', func
     st.equals(docClient.get.isSinonProxy, true);
 
     docClient.put({}, function(err, data){
-      st.equals(data, 'puttest');
+      st.equals(data, 'message');
       docClient.get({}, function(err, data){
-        st.equals(data, 'gettest');
+        st.equals(data, 'test');
 
         awsMock.restore('DynamoDB.DocumentClient', 'get');
         st.equals(AWS.DynamoDB.DocumentClient.isSinonProxy, true);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -72,7 +72,7 @@ test('AWS.mock function should mock AWS service and method on the service', func
       st.end();
     });
   });
-  t.test('method is not re-mocked if a mock already exists', function(st){
+  t.test('method is re-mocked if a mock already exists', function(st){
     awsMock.mock('SNS', 'publish', function(params, callback){
       callback(null, "message");
     });
@@ -81,11 +81,11 @@ test('AWS.mock function should mock AWS service and method on the service', func
       callback(null, "test");
     });
     sns.publish({}, function(err, data){
-      st.equals(data, 'message');
+      st.equals(data, 'test');
       st.end();
     });
   });
-  t.test('service is not re-mocked if a mock already exists', function(st){
+  t.test('service is re-mocked if a mock already exists', function(st){
     awsMock.mock('SNS', 'publish', function(params, callback){
       callback(null, "message");
     });
@@ -344,10 +344,10 @@ test('AWS.mock function should mock AWS service and method on the service', func
     awsMock.mock('DynamoDB.DocumentClient', 'put', 'message');
     var docClient = new AWS.DynamoDB.DocumentClient();
     awsMock.mock('DynamoDB.DocumentClient', 'put', function(params, callback) {
-      callback(null, 'test');
+      callback(null, 'puttest');
     });
     awsMock.mock('DynamoDB.DocumentClient', 'get', function(params, callback) {
-      callback(null, 'test');
+      callback(null, 'gettest');
     });
 
     st.equals(AWS.DynamoDB.DocumentClient.isSinonProxy, true);
@@ -355,9 +355,9 @@ test('AWS.mock function should mock AWS service and method on the service', func
     st.equals(docClient.get.isSinonProxy, true);
 
     docClient.put({}, function(err, data){
-      st.equals(data, 'message');
+      st.equals(data, 'puttest');
       docClient.get({}, function(err, data){
-        st.equals(data, 'test');
+        st.equals(data, 'gettest');
 
         awsMock.restore('DynamoDB.DocumentClient', 'get');
         st.equals(AWS.DynamoDB.DocumentClient.isSinonProxy, true);


### PR DESCRIPTION
This closes #152, allowing "remocking" of functions by calling `mock` multiple times.



