### PR TITLE
Allow constructors with more than 1 parameter to be mocked

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ function mockService(service) {
   var method = nestedServices.pop();
   var object = traverse(_AWS).get(nestedServices);
 
-  var serviceStub = sinon.stub(object, method).callsFake(function(args) {
+  var serviceStub = sinon.stub(object, method).callsFake(function(...args) {
     services[service].invoked = true;
 
     /**
@@ -96,7 +96,7 @@ function mockService(service) {
      * we stored before. E.g. var client = new AWS.SNS()
      * This is necessary in order to mock methods on the service.
      */
-    var client = new services[service].Constructor(args);
+    var client = new services[service].Constructor(...args);
     services[service].client = client;
 
     // Once this has been triggered we can mock out all the registered methods.

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -491,6 +491,14 @@ test('AWS.setSDK function should mock a specific AWS module', function(t) {
     });
   });
 
+  t.test('Modules with multi-parameter constructors can be set for mocking', function(st) {
+	awsMock.setSDK('aws-sdk');
+	awsMock.mock('CloudFront.Signer', 'getSignedUrl');
+	var signer = new AWS.CloudFront.Signer('key-pair-id', 'private-key');
+	st.ok(signer);
+	st.end();
+  });
+
   t.test('Setting the aws-sdk to the wrong module can cause an exception when mocking', function(st) {
     awsMock.setSDK('sinon');
     st.throws(function() {


### PR DESCRIPTION
This is a fix for Issue #169.