### PR TITLE
Fix wrong TypeScript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 declare module 'aws-sdk-mock' {
-  function mock(service: string, method: string, replace: string): void;
+  function mock(service: string, method: string, replace: any): void;
 
   function mock(
     service: string,
@@ -7,15 +7,14 @@ declare module 'aws-sdk-mock' {
     replace: (params: any, callback: (err: any, data: any) => void) => void
   ): void;
 
-  function remock(service: string, method: string, replace: string): void;
+  function remock(service: string, method: string, replace: any): void;
   function remock(
     service: string,
     method: string,
     replace: (params: any, callback: (err: any, data: any) => void) => void
   ): void;
 
-  function restore(service: string): void;
-  function restore(service: string, method: string): void;
+  function restore(service?: string, method?: string): void;
 
   function setSDK(path: string): void;
   function setSDKInstance(instance: object): void;


### PR DESCRIPTION
This PR addresses the following issues in the TS definitions:
* Result of an AWS method can be anything (e.g. object / Buffer for S3.getObject)
* Restore parameters are optional (can be expressed within a single line)