### PR TITLE
Add stronger type definitions for typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,21 +1,28 @@
-declare module 'aws-sdk-mock' {
-  function mock(service: string, method: string, replace: any): void;
+import AWSClientAll from "aws-sdk/clients/all";
+import AWS from "aws-sdk";
 
-  function mock(
-    service: string,
-    method: string,
-    replace: (params: any, callback: (err: any, data: any) => void) => void
-  ): void;
+export function mock<
+  T extends keyof typeof AWSClientAll,
+  K extends InstanceType<typeof AWSClientAll[T]> = InstanceType<
+    typeof AWSClientAll[T]
+  >,
+  F extends keyof K = keyof K
+>(service: T, method: F, replace: string | ((...args: any[]) => void)): void;
 
-  function remock(service: string, method: string, replace: any): void;
-  function remock(
-    service: string,
-    method: string,
-    replace: (params: any, callback: (err: any, data: any) => void) => void
-  ): void;
+export function remock<
+  T extends keyof typeof AWSClientAll,
+  K extends InstanceType<typeof AWSClientAll[T]> = InstanceType<
+    typeof AWSClientAll[T]
+  >,
+  F extends keyof K = keyof K
+>(service: T, method: F, replace: string | ((...args: any[]) => void)): void;
 
-  function restore(service?: string, method?: string): void;
+export function restore<
+  T extends keyof typeof AWSClientAll,
+  K extends keyof InstanceType<typeof AWSClientAll[T]> = keyof InstanceType<
+    typeof AWSClientAll[T]
+  >
+>(service?: T, method?: K): void;
 
-  function setSDK(path: string): void;
-  function setSDKInstance(instance: object): void;
-}
+export function setSDK(path: string): void;
+export function setSDKInstance(instance: typeof AWS): void;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,0 +1,13 @@
+import AWS from 'aws-sdk';
+import { mock, remock, restore, setSDK, setSDKInstance } from '..';
+
+// Valid mock for aws service
+mock('S3', 'createBucket', '');
+mock('S3', 'createBucket', (params: AWS.S3.CreateBucketRequest, cb) => {});
+remock('S3', 'createBucket', () => {});
+
+// Invalid mock for aws service
+mock('APIGateway', 'fnDoesNotExist', () => {});
+mock('NotAWSService', 'anyfn', () => {});
+
+setSDKInstance(AWS);


### PR DESCRIPTION
Stronger type definition for typescript inferred from `aws-sdk`

See [test/index.test.ts](https://github.com/msuntharesan/aws-sdk-mock/blob/91a821f171ceccee377d44de40f84b5b961b662f/test/index.test.ts) for usage
