### PR TITLE
Upgrade packages 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
   - "node"
-  - "6"
   - "8"
   - "10"
   - "12"

--- a/package.json
+++ b/package.json
@@ -38,15 +38,15 @@
   },
   "homepage": "https://github.com/dwyl/aws-sdk-mock#readme",
   "dependencies": {
-    "aws-sdk": "^2.431.0",
-    "sinon": "^7.3.1",
+    "aws-sdk": "^2.483.0",
+    "sinon": "^7.3.2",
     "traverse": "^0.6.6"
   },
   "devDependencies": {
     "concat-stream": "^2.0.0",
-    "eslint": "^5.15.3",
+    "eslint": "^6.0.1",
     "is-node-stream": "^1.0.0",
-    "nyc": "^13.3.0",
-    "tap": "^12.6.1"
+    "nyc": "^14.1.1",
+    "tap": "^14.3.1"
   }
 }


### PR DESCRIPTION
## Upgrade packages

I upgraded because there was also a major version of the changed package.

## Remove Node.js6 from travis.yml

* Node.js6 is EOL.
    * https://github.com/nodejs/Release
* Because tap does not support Node.js 6 or less.
    * https://github.com/tapjs/node-tap/blob/master/package.json#L11-L13