### PR TITLE
allow mocking eachPage on the AWS.Request object

### DIFF
--- a/index.js
+++ b/index.js
@@ -196,6 +196,7 @@ function mockServiceMethod(service, client, method, replace) {
         }
       } catch (e) {
         callback(e, null);
+        Object.setPrototypeOf(request, _AWS.Request.prototype);
         return request;
       }
     }
@@ -212,6 +213,7 @@ function mockServiceMethod(service, client, method, replace) {
     else {
       callback(null, replace);
     }
+    Object.setPrototypeOf(request, _AWS.Request.prototype);
     return request;
   });
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -5,6 +5,7 @@ var AWS = require('aws-sdk');
 var isNodeStream = require('is-node-stream');
 var concatStream = require('concat-stream');
 var Readable = require('stream').Readable;
+var sinon = require('sinon');
 
 AWS.config.paramValidation = false;
 
@@ -126,6 +127,16 @@ test('AWS.mock function should mock AWS service and method on the service', func
         st.end();
       });
     });
+  });
+  t.test('eachPage can be mocked on the AWS.Request object', function(st){
+    awsMock.mock('S3', 'listObjectsV2', {});
+    sinon.stub(AWS.Request.prototype, 'eachPage').callsFake(cb=>cb(null,null, function(){}));
+    var s3 = new AWS.S3();
+    s3.listObjectsV2().eachPage(function (err,data,done) {
+      done();
+      st.end();
+    })
+    sinon.restore();
   });
   if (typeof Promise === 'function') {
     t.test('promises are supported', function(st){


### PR DESCRIPTION
set the prototype of the returned request to AWS.Request

This allows to mock methods of the AWS.Request object (i.e eachPage) with standard sinon

Closes: #118