### PR TITLE
When remock is called, update all instances of client

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,11 +121,9 @@ function mockService(service) {
  *  - callback: of the form 'function(err, data) {}'.
  */
 function mockServiceMethod(service, client, method, replace) {
-  
   if (client[method] && typeof client[method].restore === 'function') {
     client[method].restore();
   }
-  
   services[service].methodMocks[method].stub = sinon.stub(client, method).callsFake(function() {
     const args = Array.prototype.slice.call(arguments);
 

--- a/index.js
+++ b/index.js
@@ -283,7 +283,12 @@ function restoreAllMethods(service) {
 function restoreMethod(service, method) {
   if (services[service] && services[service].methodMocks[method]) {
     if (services[service].methodMocks[method].stub) {
-      services[service].methodMocks[method].stub.restore();
+      // restore this method on all clients
+      services[service].clients.forEach(client => {
+        if (client[method] && typeof client[method].restore === 'function') {
+          client[method].restore();
+        }
+      })
     }
     delete services[service].methodMocks[method];
   } else {

--- a/index.js
+++ b/index.js
@@ -121,9 +121,6 @@ function mockService(service) {
  *  - callback: of the form 'function(err, data) {}'.
  */
 function mockServiceMethod(service, client, method, replace) {
-  if (client[method] && typeof client[method].restore === 'function') {
-    client[method].restore();
-  }
   services[service].methodMocks[method].stub = sinon.stub(client, method).callsFake(function() {
     const args = Array.prototype.slice.call(arguments);
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -348,16 +348,16 @@ test('AWS.mock function should mock AWS service and method on the service', func
     awsMock.mock('SNS', 'publish', function(params, callback){
       callback(null, 'message');
     });
-    
+
     const sns1 = new AWS.SNS();
     const sns2 = new AWS.SNS();
-      
+
     st.equals(AWS.SNS.isSinonProxy, true);
     st.equals(sns1.publish.isSinonProxy, true);
     st.equals(sns2.publish.isSinonProxy, true);
-    
+
     awsMock.restore('SNS', 'publish');
-    
+
     st.equals(AWS.SNS.hasOwnProperty('isSinonProxy'), true);
     st.equals(sns1.publish.hasOwnProperty('isSinonProxy'), false);
     st.equals(sns2.publish.hasOwnProperty('isSinonProxy'), false);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -113,6 +113,28 @@ test('AWS.mock function should mock AWS service and method on the service', func
       st.end();
     });
   });
+  t.test('all instances of service are re-mocked when remock called', function(st){
+    awsMock.mock('SNS', 'subscribe', function(params, callback){
+      callback(null, 'message 1');
+    });
+    const sns1 = new AWS.SNS();
+    const sns2 = new AWS.SNS();
+    
+    awsMock.remock('SNS', 'subscribe', function(params, callback){
+      callback(null, 'message 2');
+    });
+    
+    sns1.subscribe({}, function(err, data){
+      st.equals(data, 'message 2');
+      
+      sns2.subscribe({}, function(err, data){
+        st.equals(data, 'message 2');
+        st.end();
+      });
+      
+    });
+  });
+  
   t.test('multiple methods can be mocked on the same service', function(st){
     awsMock.mock('Lambda', 'getFunction', function(params, callback) {
       callback(null, 'message');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -131,7 +131,6 @@ test('AWS.mock function should mock AWS service and method on the service', func
         st.equals(data, 'message 2');
         st.end();
       });
-
     });
   });
   t.test('multiple methods can be mocked on the same service', function(st){

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -310,7 +310,6 @@ test('AWS.mock function should mock AWS service and method on the service', func
     st.equals(AWS.SNS.hasOwnProperty('isSinonProxy'), false);
     st.end();
   });
-  
   t.test('only the method on the service is restored', function(st){
     awsMock.mock('SNS', 'publish', function(params, callback){
       callback(null, 'message');
@@ -325,10 +324,9 @@ test('AWS.mock function should mock AWS service and method on the service', func
     st.equals(sns.publish.hasOwnProperty('isSinonProxy'), false);
     st.end();
   });
-
-  t.test('methods on all service instances are restored', function(st){
+  t.test('method on all service instances are restored', function(st){
     awsMock.mock('SNS', 'publish', function(params, callback){
-        callback(null, 'message');
+      callback(null, 'message');
     });
     
     const sns1 = new AWS.SNS();
@@ -345,7 +343,25 @@ test('AWS.mock function should mock AWS service and method on the service', func
     st.equals(sns2.publish.hasOwnProperty('isSinonProxy'), false);
     st.end();
   });
-  
+  t.test('all methods on all service instances are restored', function(st){
+    awsMock.mock('SNS', 'publish', function(params, callback){
+      callback(null, 'message');
+    });
+
+    const sns1 = new AWS.SNS();
+    const sns2 = new AWS.SNS();
+
+    st.equals(AWS.SNS.isSinonProxy, true);
+    st.equals(sns1.publish.isSinonProxy, true);
+    st.equals(sns2.publish.isSinonProxy, true);
+
+    awsMock.restore('SNS');
+
+    st.equals(AWS.SNS.hasOwnProperty('isSinonProxy'), false);
+    st.equals(sns1.publish.hasOwnProperty('isSinonProxy'), false);
+    st.equals(sns2.publish.hasOwnProperty('isSinonProxy'), false);
+    st.end();
+  });
   t.test('all the services are restored when no arguments given to awsMock.restore', function(st){
     awsMock.mock('SNS', 'publish', function(params, callback){
       callback(null, 'message');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -113,28 +113,6 @@ test('AWS.mock function should mock AWS service and method on the service', func
       st.end();
     });
   });
-  t.test('all instances of service are re-mocked when remock called', function(st){
-    awsMock.mock('SNS', 'subscribe', function(params, callback){
-      callback(null, 'message 1');
-    });
-    const sns1 = new AWS.SNS();
-    const sns2 = new AWS.SNS();
-    
-    awsMock.remock('SNS', 'subscribe', function(params, callback){
-      callback(null, 'message 2');
-    });
-    
-    sns1.subscribe({}, function(err, data){
-      st.equals(data, 'message 2');
-      
-      sns2.subscribe({}, function(err, data){
-        st.equals(data, 'message 2');
-        st.end();
-      });
-      
-    });
-  });
-  
   t.test('multiple methods can be mocked on the same service', function(st){
     awsMock.mock('Lambda', 'getFunction', function(params, callback) {
       callback(null, 'message');
@@ -332,6 +310,7 @@ test('AWS.mock function should mock AWS service and method on the service', func
     st.equals(AWS.SNS.hasOwnProperty('isSinonProxy'), false);
     st.end();
   });
+  
   t.test('only the method on the service is restored', function(st){
     awsMock.mock('SNS', 'publish', function(params, callback){
       callback(null, 'message');
@@ -346,6 +325,27 @@ test('AWS.mock function should mock AWS service and method on the service', func
     st.equals(sns.publish.hasOwnProperty('isSinonProxy'), false);
     st.end();
   });
+
+  t.test('methods on all service instances are restored', function(st){
+    awsMock.mock('SNS', 'publish', function(params, callback){
+        callback(null, 'message');
+    });
+    
+    const sns1 = new AWS.SNS();
+    const sns2 = new AWS.SNS();
+      
+    st.equals(AWS.SNS.isSinonProxy, true);
+    st.equals(sns1.publish.isSinonProxy, true);
+    st.equals(sns2.publish.isSinonProxy, true);
+    
+    awsMock.restore('SNS', 'publish');
+    
+    st.equals(AWS.SNS.hasOwnProperty('isSinonProxy'), true);
+    st.equals(sns1.publish.hasOwnProperty('isSinonProxy'), false);
+    st.equals(sns2.publish.hasOwnProperty('isSinonProxy'), false);
+    st.end();
+  });
+  
   t.test('all the services are restored when no arguments given to awsMock.restore', function(st){
     awsMock.mock('SNS', 'publish', function(params, callback){
       callback(null, 'message');


### PR DESCRIPTION
**Issues**
1) When some client has multiple instances, and we do remock, not all instances are updated
2) When some client has multiple instances, and we do restore, not all instances are restored

**How to reproduce issue 1** 

```
// mock DynamoDB.getItem
awsMock.mock('DynamoDB', 'getItem', function(params, callback){
      callback(null, 'value1');
});

// you have multiple instances in your code
const ddb1 = new AWS.DynamoDB();
const ddb2 = new AWS.DynamoDB();
    
awsMock.remock('DynamoDB', 'getItem', function(params, callback){
   callback(null, 'value2');
});
```
Currently, only ONE of instances is updated in this case, and that is strange.
`ddb1.getItem()` returns value1, and `ddb2.getItem()` returns value2.

**How to reproduce issue 2** 

```
awsMock.mock('SNS', 'publish', function(params, callback){
      callback(null, 'message');
});

const sns1 = new AWS.SNS();
const sns2 = new AWS.SNS();

// publish function on both instances is mocked

st.equals(AWS.SNS.isSinonProxy, true);
st.equals(sns1.publish.isSinonProxy, true);
st.equals(sns2.publish.isSinonProxy, true);

 awsMock.restore('SNS', 'publish');

// only publish function on second instance (sns2) is restored
```


Issue is described here https://github.com/dwyl/aws-sdk-mock/issues/219