### PR TITLE
remove old (no longer supported) versions of node.js from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,6 @@
 language: node_js
 node_js:
-  - "node"
-  - "8"
-  - "10"
   - "12"
   - "14"
-before_install:
-  - pip install --user codecov
 after_success:
-  - codecov --file coverage/lcov.info --disable search
+  - bash <(curl -s https://codecov.io/bash)

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "homepage": "https://github.com/dwyl/aws-sdk-mock#readme",
   "dependencies": {
-    "aws-sdk": "^2.710.0",
+    "aws-sdk": "^2.928.0",
     "sinon": "^11.1.1",
     "traverse": "^0.6.6"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-sdk-mock",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Functions to mock the JavaScript aws-sdk ",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "homepage": "https://github.com/dwyl/aws-sdk-mock#readme",
   "dependencies": {
     "aws-sdk": "^2.710.0",
-    "sinon": "^9.0.2",
+    "sinon": "^11.1.1",
     "traverse": "^0.6.6"
   },
   "devDependencies": {


### PR DESCRIPTION
+ [x] fixes #237