### PR TITLE
Provide stricter typing for services and methods

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,22 +1,43 @@
-declare module 'aws-sdk-mock' {
-  function mock(
-    service: string,
-    method: string,
-    replace: (params: any, callback: (err: any, data: any) => void) => void
-  ): void;
+// TypeScript Version: 3.2
+import { Request, AWSError } from 'aws-sdk/lib/core';
+import AWS = require('aws-sdk/clients/all');
 
-  function mock(service: string, method: string, replace: any): void;
+export type ClientName = keyof typeof AWS;
+export type Client<C extends ClientName> = InstanceType<(typeof AWS)[C]>;
 
-  function remock(
-    service: string,
-    method: string,
-    replace: (params: any, callback: (err: any, data: any) => void) => void
-  ): void;
+export type ExtractMethod<T extends {}> = { [K in keyof T]: T[K] extends (...args: any[]) => any ? T[K] : never };
 
-  function remock(service: string, method: string, replace: any): void;
+export type MethodName<C extends ClientName> = keyof ExtractMethod<Client<C>>;
+export type Method<C extends ClientName, M extends MethodName<C>> = ExtractMethod<Client<C>>[M];
 
-  function restore(service?: string, method?: string): void;
+export type AWSRequest<C extends ClientName, M extends MethodName<C>> = Method<C, M> extends AWSMethod<infer P, any> ? P : never;
+export type AWSCallback<C extends ClientName, M extends MethodName<C>> = Method<C, M> extends AWSMethod<any, infer D> ? {
+  (err: undefined, data: D): void;
+  (err: AWSError, data?: undefined): void;
+} : never;
 
-  function setSDK(path: string): void;
-  function setSDKInstance(instance: object): void;
+export interface AWSMethod<P, D> {
+  (params: P, callback?: Callback<D>): Request<D, AWSError>;
+  (callback?: Callback<D>): Request<D, AWSError>;
 }
+
+export type Callback<D> = (err: AWSError | undefined, data: D) => void;
+
+export function mock<C extends ClientName, M extends MethodName<C>>(
+  service: C,
+  method: M,
+  replace: (params: AWSRequest<C, M>, callback: AWSCallback<C, M>) => void
+): void;
+export function mock<C extends ClientName>(service: C, method: MethodName<C>, replace: any): void;
+
+export function remock<C extends ClientName, M extends MethodName<C>>(
+  service: C,
+  method: M,
+  replace: (params: AWSRequest<C, M>, callback: AWSCallback<C, M>) => void
+): void;
+export function remock<C extends ClientName>(service: C, method: MethodName<C>, replace: any): void;
+
+export function restore<C extends ClientName>(service?: C, method?: MethodName<C>): void;
+
+export function setSDK(path: string): void;
+export function setSDKInstance(instance: typeof import('aws-sdk')): void;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-sdk-mock",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -731,6 +731,32 @@
         "chalk": "^4.0.0"
       }
     },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -809,6 +835,22 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/eslint": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.29.0.tgz",
+      "integrity": "sha512-VNcvioYDH8/FxaeTKkM4/TiTwt6pBV9E3OfGmvaw8tPl0rrHCJ4Ll15HRT+pMiFAf/MLQvAzC+6RzUMEL9Ceng==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "@types/estree": {
+      "version": "0.0.50",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
+      "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
+      "dev": true
+    },
     "@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -842,10 +884,28 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/json-schema": {
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
+      "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+      "dev": true
+    },
+    "@types/minimist": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+      "dev": true
+    },
     "@types/node": {
       "version": "16.11.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.10.tgz",
       "integrity": "sha512-3aRnHa1KlOEEhJ6+CvyHKK5vE9BcLGjtUpwvqYLRvYNQKMfabu3BwfJaA/SLW8dxe28LsNDjtHwePTuzn3gmOA==",
+      "dev": true
+    },
+    "@types/normalize-package-data": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
+      "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
     },
     "@types/prettier": {
@@ -964,9 +1024,9 @@
       }
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
     "ansi-styles": {
@@ -1012,10 +1072,22 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
     "asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
       "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
@@ -1034,9 +1106,9 @@
       "dev": true
     },
     "async-hook-domain": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/async-hook-domain/-/async-hook-domain-2.0.3.tgz",
-      "integrity": "sha512-MadiLLDEZRZzZwcm0dgS+K99qXZ4H2saAUwUgwzFulbAkXrKi3AX5FvWS3FFTQtLMwrqcGqAJe6o12KrObejQA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/async-hook-domain/-/async-hook-domain-2.0.4.tgz",
+      "integrity": "sha512-14LjCmlK1PK8eDtTezR6WX8TMaYNIzBIsd2D1sGoGjgx0BuNMMoSdk7i/drlbtamy0AWv9yv2tkB+ASdmeqFIw==",
       "dev": true
     },
     "asynckit": {
@@ -1296,6 +1368,17 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
     },
+    "camelcase-keys": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      }
+    },
     "caniuse-lite": {
       "version": "1.0.30001237",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001237.tgz",
@@ -1399,12 +1482,6 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
-    },
-    "code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
     "collect-v8-coverage": {
@@ -1578,6 +1655,24 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
+    "decamelize-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+      "dev": true,
+      "requires": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      },
+      "dependencies": {
+        "map-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+          "dev": true
+        }
+      }
+    },
     "decimal.js": {
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
@@ -1633,6 +1728,15 @@
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.0.6.tgz",
       "integrity": "sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ==",
       "dev": true
+    },
+    "dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "requires": {
+        "path-type": "^4.0.0"
+      }
     },
     "doctrine": {
       "version": "3.0.0",
@@ -1695,6 +1799,15 @@
       "dev": true,
       "requires": {
         "ansi-colors": "^4.1.1"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
       }
     },
     "es6-error": {
@@ -1828,6 +1941,28 @@
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
       }
+    },
+    "eslint-formatter-pretty": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-4.1.0.tgz",
+      "integrity": "sha512-IsUTtGxF1hrH6lMWiSl1WbGaiP01eT6kzywdY1U+zLc0MP+nwEnUiS9UI8IaOTUhTeQJLlCEWIbXINBH4YJbBQ==",
+      "dev": true,
+      "requires": {
+        "@types/eslint": "^7.2.13",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.0",
+        "eslint-rule-docs": "^1.1.5",
+        "log-symbols": "^4.0.0",
+        "plur": "^4.0.0",
+        "string-width": "^4.2.0",
+        "supports-hyperlinks": "^2.0.0"
+      }
+    },
+    "eslint-rule-docs": {
+      "version": "1.1.231",
+      "resolved": "https://registry.npmjs.org/eslint-rule-docs/-/eslint-rule-docs-1.1.231.tgz",
+      "integrity": "sha512-egHz9A1WG7b8CS0x1P6P/Rj5FqZOjray/VjpJa14tMZalfRKvpE2ONJ3plCM7+PcinmU4tcmbPLv0VtwzSdLVA==",
+      "dev": true
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -2007,6 +2142,19 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
+    "fast-glob": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
+      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      }
+    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2018,6 +2166,15 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fastq": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.4"
+      }
     },
     "fb-watchman": {
       "version": "2.0.1",
@@ -2224,6 +2381,28 @@
         "type-fest": "^0.20.2"
       }
     },
+    "globby": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+      "dev": true,
+      "requires": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.1.1",
+        "ignore": "^5.1.4",
+        "merge2": "^1.3.0",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+          "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+          "dev": true
+        }
+      }
+    },
     "graceful-fs": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
@@ -2245,6 +2424,12 @@
         "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
       }
+    },
+    "hard-rejection": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
+      "dev": true
     },
     "has": {
       "version": "1.0.3",
@@ -2276,6 +2461,15 @@
           "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
           "dev": true
         }
+      }
+    },
+    "hosted-git-info": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
+      "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
       }
     },
     "html-encoding-sniffer": {
@@ -2399,6 +2593,18 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "irregular-plurals": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.3.0.tgz",
+      "integrity": "sha512-MVBLKUTangM3EfRPFROhmWQQKRDsrgI83J8GS3jXy+OwYqiR2/aoWndYQ5416jLE3uaGgLH7ncme3X9y09gZ3g==",
+      "dev": true
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
     "is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -2475,6 +2681,12 @@
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
     },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
+    },
     "is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -2501,6 +2713,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true
     },
     "is-windows": {
@@ -2625,101 +2843,58 @@
       }
     },
     "jackspeak": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-1.4.0.tgz",
-      "integrity": "sha512-VDcSunT+wcccoG46FtzuBAyQKlzhHjli4q31e1fIHGOsRspqNUFjVzGb+7eIFDlTvqLygxapDHPHS0ouT2o/tw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-1.4.1.tgz",
+      "integrity": "sha512-npN8f+M4+IQ8xD3CcWi3U62VQwKlT3Tj4GxbdT/fYTmeogD9eBF9OFdpoFG/VPNoshRjPUijdkp/p2XrzUHaVg==",
       "dev": true,
       "requires": {
-        "cliui": "^4.1.0"
+        "cliui": "^7.0.4"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
         },
         "cliui": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
           "dev": true,
           "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^7.0.0"
           }
         },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        },
         "wrap-ansi": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
           "dev": true,
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-              "dev": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-              "dev": true,
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              }
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              }
-            }
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
           }
         }
       }
@@ -3523,10 +3698,16 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
+    },
     "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true
     },
     "json-schema-traverse": {
@@ -3557,14 +3738,14 @@
       }
     },
     "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
       }
     },
@@ -3572,6 +3753,12 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
       "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg=="
+    },
+    "kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true
     },
     "kleur": {
       "version": "3.0.3",
@@ -3602,23 +3789,23 @@
       }
     },
     "libtap": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/libtap/-/libtap-1.1.1.tgz",
-      "integrity": "sha512-Fye8fh1+G7E8qqmjQaY+pXGxy7HM0S6bqCCJFLa16+g2jODBByxbJFDpjbDNF69wfRVyvJ+foLZc1WTIv7dx+g==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/libtap/-/libtap-1.1.3.tgz",
+      "integrity": "sha512-BfbhcSlcFngZWYvDt+gs4m1BkjP0LaFEg6+4FBAXD0E8Br95wpXCCvS5JZHW1a5QPWMrFD4LhsqBpTPRB3Em8g==",
       "dev": true,
       "requires": {
-        "async-hook-domain": "^2.0.1",
+        "async-hook-domain": "^2.0.4",
         "bind-obj-methods": "^3.0.0",
         "diff": "^4.0.2",
         "function-loop": "^2.0.1",
-        "minipass": "^3.1.1",
+        "minipass": "^3.1.5",
         "own-or": "^1.0.0",
-        "own-or-env": "^1.0.1",
-        "signal-exit": "^3.0.2",
-        "stack-utils": "^2.0.1",
+        "own-or-env": "^1.0.2",
+        "signal-exit": "^3.0.4",
+        "stack-utils": "^2.0.4",
         "tap-parser": "^10.0.1",
         "tap-yaml": "^1.0.0",
-        "tcompare": "^5.0.1",
+        "tcompare": "^5.0.6",
         "trivial-deferred": "^1.0.1",
         "yapool": "^1.0.0"
       },
@@ -3628,8 +3815,35 @@
           "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
           "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
           "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
+          "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==",
+          "dev": true
+        },
+        "stack-utils": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
+          "integrity": "sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^2.0.0"
+          }
         }
       }
+    },
+    "lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
     },
     "locate-path": {
       "version": "5.0.0",
@@ -3681,13 +3895,14 @@
       "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
       "dev": true
     },
-    "loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+    "log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
       "dev": true,
       "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
       }
     },
     "lru-cache": {
@@ -3725,10 +3940,56 @@
         "tmpl": "1.0.5"
       }
     },
+    "map-obj": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+      "dev": true
+    },
+    "meow": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
+      "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
+      "dev": true,
+      "requires": {
+        "@types/minimist": "^1.2.0",
+        "camelcase-keys": "^6.2.2",
+        "decamelize": "^1.2.0",
+        "decamelize-keys": "^1.1.0",
+        "hard-rejection": "^2.1.0",
+        "minimist-options": "4.1.0",
+        "normalize-package-data": "^3.0.0",
+        "read-pkg-up": "^7.0.1",
+        "redent": "^3.0.0",
+        "trim-newlines": "^3.0.0",
+        "type-fest": "^0.18.0",
+        "yargs-parser": "^20.2.3"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.18.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+          "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+          "dev": true
+        },
+        "yargs-parser": {
+          "version": "20.2.9",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+          "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+          "dev": true
+        }
+      }
+    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true
     },
     "micromatch": {
@@ -3762,6 +4023,12 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
     },
+    "min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -3777,10 +4044,21 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
+    "minimist-options": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0",
+        "kind-of": "^6.0.3"
+      }
+    },
     "minipass": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
-      "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+      "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
       "dev": true,
       "requires": {
         "yallist": "^4.0.0"
@@ -3843,6 +4121,18 @@
       "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
       "dev": true
     },
+    "normalize-package-data": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^4.0.1",
+        "is-core-module": "^2.5.0",
+        "semver": "^7.3.4",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -3857,12 +4147,6 @@
       "requires": {
         "path-key": "^3.0.0"
       }
-    },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
     },
     "nwsapi": {
       "version": "2.2.0",
@@ -3919,12 +4203,6 @@
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true
     },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3970,9 +4248,9 @@
       "dev": true
     },
     "own-or-env": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/own-or-env/-/own-or-env-1.0.1.tgz",
-      "integrity": "sha512-y8qULRbRAlL6x2+M0vIe7jJbJx/kmUTzYonRAa2ayesR2qWLswninkVyeJe4x3IEXhdgoNodzjQRKAoEs6Fmrw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/own-or-env/-/own-or-env-1.0.2.tgz",
+      "integrity": "sha512-NQ7v0fliWtK7Lkb+WdFqe6ky9XAzYmlkXthQrBbzlYbmFKoAYbDDcwmOm6q8kOuwSRXW8bdL5ORksploUJmWgw==",
       "dev": true,
       "requires": {
         "own-or": "^1.0.0"
@@ -4032,6 +4310,18 @@
         "callsites": "^3.0.0"
       }
     },
+    "parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      }
+    },
     "parse5": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
@@ -4077,6 +4367,12 @@
         }
       }
     },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -4105,6 +4401,15 @@
       "dev": true,
       "requires": {
         "find-up": "^4.0.0"
+      }
+    },
+    "plur": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/plur/-/plur-4.0.0.tgz",
+      "integrity": "sha512-4UGewrYgqDFw9vV6zNV+ADmPAUAfJPKtGvb/VdpQAx25X5f3xXdGdyOEVFwkl8Hl/tl7+xbeHqSEM+D5/TirUg==",
+      "dev": true,
+      "requires": {
+        "irregular-plurals": "^3.2.0"
       }
     },
     "prelude-ls": {
@@ -4170,17 +4475,6 @@
         "sisteransi": "^1.0.5"
       }
     },
-    "prop-types": {
-      "version": "15.7.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.8.1"
-      }
-    },
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -4203,22 +4497,80 @@
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
-    "react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true
+    },
+    "quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "dev": true
+    },
+    "read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
       "dev": true,
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "dependencies": {
+        "hosted-git-info": {
+          "version": "2.8.9",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+          "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+          "dev": true
+        },
+        "normalize-package-data": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "resolve": "^1.10.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+          "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+          "dev": true
+        }
       }
     },
-    "react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+    "read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "dev": true,
+      "requires": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
+        }
+      }
     },
     "readable-stream": {
       "version": "3.6.0",
@@ -4238,6 +4590,16 @@
       "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
+      }
+    },
+    "redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "requires": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
       }
     },
     "regexpp": {
@@ -4340,6 +4702,12 @@
       "integrity": "sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==",
       "dev": true
     },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
+    },
     "rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -4347,6 +4715,15 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
+      }
+    },
+    "run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "requires": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "safe-buffer": {
@@ -4511,6 +4888,38 @@
         "which": "^2.0.1"
       }
     },
+    "spdx-correct": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
+      "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
+      "dev": true
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -4602,6 +5011,15 @@
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "dev": true
     },
+    "strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "requires": {
+        "min-indent": "^1.0.0"
+      }
+    },
     "strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -4667,67 +5085,67 @@
       }
     },
     "tap": {
-      "version": "15.0.9",
-      "resolved": "https://registry.npmjs.org/tap/-/tap-15.0.9.tgz",
-      "integrity": "sha512-bqY5SxEqYKRd37PIUfKBf9HMs/hklyl/fGXkuStr9rYTIGa0/icpSLsm6IVOmx2qT0/TliPNJ6OvS5kddJYHdg==",
+      "version": "15.1.5",
+      "resolved": "https://registry.npmjs.org/tap/-/tap-15.1.5.tgz",
+      "integrity": "sha512-ha9ify0cagIOENV5D+T8ys+FFOWqPaWAKk66hjtUWjywXdGmnL8LRxloZa8sHiaB+Az1GYx4ufEaflOpedSCbQ==",
       "dev": true,
       "requires": {
-        "@types/react": "^16.9.23",
+        "@isaacs/import-jsx": "^4.0.1",
+        "@types/react": "^17",
         "chokidar": "^3.3.0",
         "coveralls": "^3.0.11",
         "findit": "^2.0.0",
         "foreground-child": "^2.0.0",
         "fs-exists-cached": "^1.0.0",
         "glob": "^7.1.6",
-        "import-jsx": "^4.0.0",
-        "ink": "^2.7.1",
+        "ink": "^3.2.0",
         "isexe": "^2.0.0",
         "istanbul-lib-processinfo": "^2.0.2",
-        "jackspeak": "^1.4.0",
-        "libtap": "^1.1.1",
+        "jackspeak": "^1.4.1",
+        "libtap": "^1.1.3",
         "minipass": "^3.1.1",
         "mkdirp": "^1.0.4",
         "nyc": "^15.1.0",
         "opener": "^1.5.1",
-        "react": "^16.12.0",
+        "react": "^17.0.2",
         "rimraf": "^3.0.0",
-        "signal-exit": "^3.0.0",
+        "signal-exit": "^3.0.6",
         "source-map-support": "^0.5.16",
         "tap-mocha-reporter": "^5.0.0",
         "tap-parser": "^10.0.1",
         "tap-yaml": "^1.0.0",
         "tcompare": "^5.0.6",
-        "treport": "^2.0.2",
+        "treport": "^3.0.2",
         "which": "^2.0.2"
       },
       "dependencies": {
         "@babel/code-frame": {
-          "version": "7.12.13",
+          "version": "7.16.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.12.13"
+            "@babel/highlight": "^7.16.0"
           }
         },
         "@babel/compat-data": {
-          "version": "7.14.0",
+          "version": "7.16.0",
           "bundled": true,
           "dev": true
         },
         "@babel/core": {
-          "version": "7.14.0",
+          "version": "7.16.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@babel/code-frame": "^7.12.13",
-            "@babel/generator": "^7.14.0",
-            "@babel/helper-compilation-targets": "^7.13.16",
-            "@babel/helper-module-transforms": "^7.14.0",
-            "@babel/helpers": "^7.14.0",
-            "@babel/parser": "^7.14.0",
-            "@babel/template": "^7.12.13",
-            "@babel/traverse": "^7.14.0",
-            "@babel/types": "^7.14.0",
+            "@babel/code-frame": "^7.16.0",
+            "@babel/generator": "^7.16.0",
+            "@babel/helper-compilation-targets": "^7.16.0",
+            "@babel/helper-module-transforms": "^7.16.0",
+            "@babel/helpers": "^7.16.0",
+            "@babel/parser": "^7.16.0",
+            "@babel/template": "^7.16.0",
+            "@babel/traverse": "^7.16.0",
+            "@babel/types": "^7.16.0",
             "convert-source-map": "^1.7.0",
             "debug": "^4.1.0",
             "gensync": "^1.0.0-beta.2",
@@ -4737,176 +5155,184 @@
           }
         },
         "@babel/generator": {
-          "version": "7.14.1",
+          "version": "7.16.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@babel/types": "^7.14.1",
+            "@babel/types": "^7.16.0",
             "jsesc": "^2.5.1",
             "source-map": "^0.5.0"
           }
         },
         "@babel/helper-annotate-as-pure": {
-          "version": "7.12.13",
+          "version": "7.16.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@babel/types": "^7.12.13"
+            "@babel/types": "^7.16.0"
           }
         },
         "@babel/helper-compilation-targets": {
-          "version": "7.13.16",
+          "version": "7.16.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@babel/compat-data": "^7.13.15",
-            "@babel/helper-validator-option": "^7.12.17",
-            "browserslist": "^4.14.5",
+            "@babel/compat-data": "^7.16.0",
+            "@babel/helper-validator-option": "^7.14.5",
+            "browserslist": "^4.17.5",
             "semver": "^6.3.0"
           }
         },
         "@babel/helper-function-name": {
-          "version": "7.12.13",
+          "version": "7.16.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@babel/helper-get-function-arity": "^7.12.13",
-            "@babel/template": "^7.12.13",
-            "@babel/types": "^7.12.13"
+            "@babel/helper-get-function-arity": "^7.16.0",
+            "@babel/template": "^7.16.0",
+            "@babel/types": "^7.16.0"
           }
         },
         "@babel/helper-get-function-arity": {
-          "version": "7.12.13",
+          "version": "7.16.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@babel/types": "^7.12.13"
+            "@babel/types": "^7.16.0"
+          }
+        },
+        "@babel/helper-hoist-variables": {
+          "version": "7.16.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.16.0"
           }
         },
         "@babel/helper-member-expression-to-functions": {
-          "version": "7.13.12",
+          "version": "7.16.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@babel/types": "^7.13.12"
+            "@babel/types": "^7.16.0"
           }
         },
         "@babel/helper-module-imports": {
-          "version": "7.13.12",
+          "version": "7.16.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@babel/types": "^7.13.12"
+            "@babel/types": "^7.16.0"
           }
         },
         "@babel/helper-module-transforms": {
-          "version": "7.14.0",
+          "version": "7.16.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@babel/helper-module-imports": "^7.13.12",
-            "@babel/helper-replace-supers": "^7.13.12",
-            "@babel/helper-simple-access": "^7.13.12",
-            "@babel/helper-split-export-declaration": "^7.12.13",
-            "@babel/helper-validator-identifier": "^7.14.0",
-            "@babel/template": "^7.12.13",
-            "@babel/traverse": "^7.14.0",
-            "@babel/types": "^7.14.0"
+            "@babel/helper-module-imports": "^7.16.0",
+            "@babel/helper-replace-supers": "^7.16.0",
+            "@babel/helper-simple-access": "^7.16.0",
+            "@babel/helper-split-export-declaration": "^7.16.0",
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "@babel/template": "^7.16.0",
+            "@babel/traverse": "^7.16.0",
+            "@babel/types": "^7.16.0"
           }
         },
         "@babel/helper-optimise-call-expression": {
-          "version": "7.12.13",
+          "version": "7.16.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@babel/types": "^7.12.13"
+            "@babel/types": "^7.16.0"
           }
         },
         "@babel/helper-plugin-utils": {
-          "version": "7.13.0",
+          "version": "7.14.5",
           "bundled": true,
           "dev": true
         },
         "@babel/helper-replace-supers": {
-          "version": "7.13.12",
+          "version": "7.16.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@babel/helper-member-expression-to-functions": "^7.13.12",
-            "@babel/helper-optimise-call-expression": "^7.12.13",
-            "@babel/traverse": "^7.13.0",
-            "@babel/types": "^7.13.12"
+            "@babel/helper-member-expression-to-functions": "^7.16.0",
+            "@babel/helper-optimise-call-expression": "^7.16.0",
+            "@babel/traverse": "^7.16.0",
+            "@babel/types": "^7.16.0"
           }
         },
         "@babel/helper-simple-access": {
-          "version": "7.13.12",
+          "version": "7.16.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@babel/types": "^7.13.12"
+            "@babel/types": "^7.16.0"
           }
         },
         "@babel/helper-split-export-declaration": {
-          "version": "7.12.13",
+          "version": "7.16.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@babel/types": "^7.12.13"
+            "@babel/types": "^7.16.0"
           }
         },
         "@babel/helper-validator-identifier": {
-          "version": "7.14.0",
+          "version": "7.15.7",
           "bundled": true,
           "dev": true
         },
         "@babel/helper-validator-option": {
-          "version": "7.12.17",
+          "version": "7.14.5",
           "bundled": true,
           "dev": true
         },
         "@babel/helpers": {
-          "version": "7.14.0",
+          "version": "7.16.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@babel/template": "^7.12.13",
-            "@babel/traverse": "^7.14.0",
-            "@babel/types": "^7.14.0"
+            "@babel/template": "^7.16.0",
+            "@babel/traverse": "^7.16.3",
+            "@babel/types": "^7.16.0"
           }
         },
         "@babel/highlight": {
-          "version": "7.14.0",
+          "version": "7.16.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@babel/helper-validator-identifier": "^7.14.0",
+            "@babel/helper-validator-identifier": "^7.15.7",
             "chalk": "^2.0.0",
             "js-tokens": "^4.0.0"
           }
         },
         "@babel/parser": {
-          "version": "7.14.1",
+          "version": "7.16.3",
           "bundled": true,
           "dev": true
         },
         "@babel/plugin-proposal-object-rest-spread": {
-          "version": "7.13.8",
+          "version": "7.16.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@babel/compat-data": "^7.13.8",
-            "@babel/helper-compilation-targets": "^7.13.8",
-            "@babel/helper-plugin-utils": "^7.13.0",
+            "@babel/compat-data": "^7.16.0",
+            "@babel/helper-compilation-targets": "^7.16.0",
+            "@babel/helper-plugin-utils": "^7.14.5",
             "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-            "@babel/plugin-transform-parameters": "^7.13.0"
+            "@babel/plugin-transform-parameters": "^7.16.0"
           }
         },
         "@babel/plugin-syntax-jsx": {
-          "version": "7.12.13",
+          "version": "7.16.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@babel/helper-plugin-utils": "^7.12.13"
+            "@babel/helper-plugin-utils": "^7.14.5"
           }
         },
         "@babel/plugin-syntax-object-rest-spread": {
@@ -4918,74 +5344,114 @@
           }
         },
         "@babel/plugin-transform-destructuring": {
-          "version": "7.13.17",
+          "version": "7.16.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@babel/helper-plugin-utils": "^7.13.0"
+            "@babel/helper-plugin-utils": "^7.14.5"
           }
         },
         "@babel/plugin-transform-parameters": {
-          "version": "7.13.0",
+          "version": "7.16.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@babel/helper-plugin-utils": "^7.13.0"
+            "@babel/helper-plugin-utils": "^7.14.5"
           }
         },
         "@babel/plugin-transform-react-jsx": {
-          "version": "7.13.12",
+          "version": "7.16.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@babel/helper-annotate-as-pure": "^7.12.13",
-            "@babel/helper-module-imports": "^7.13.12",
-            "@babel/helper-plugin-utils": "^7.13.0",
-            "@babel/plugin-syntax-jsx": "^7.12.13",
-            "@babel/types": "^7.13.12"
+            "@babel/helper-annotate-as-pure": "^7.16.0",
+            "@babel/helper-module-imports": "^7.16.0",
+            "@babel/helper-plugin-utils": "^7.14.5",
+            "@babel/plugin-syntax-jsx": "^7.16.0",
+            "@babel/types": "^7.16.0"
           }
         },
         "@babel/template": {
-          "version": "7.12.13",
+          "version": "7.16.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@babel/code-frame": "^7.12.13",
-            "@babel/parser": "^7.12.13",
-            "@babel/types": "^7.12.13"
+            "@babel/code-frame": "^7.16.0",
+            "@babel/parser": "^7.16.0",
+            "@babel/types": "^7.16.0"
           }
         },
         "@babel/traverse": {
-          "version": "7.14.0",
+          "version": "7.16.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@babel/code-frame": "^7.12.13",
-            "@babel/generator": "^7.14.0",
-            "@babel/helper-function-name": "^7.12.13",
-            "@babel/helper-split-export-declaration": "^7.12.13",
-            "@babel/parser": "^7.14.0",
-            "@babel/types": "^7.14.0",
+            "@babel/code-frame": "^7.16.0",
+            "@babel/generator": "^7.16.0",
+            "@babel/helper-function-name": "^7.16.0",
+            "@babel/helper-hoist-variables": "^7.16.0",
+            "@babel/helper-split-export-declaration": "^7.16.0",
+            "@babel/parser": "^7.16.3",
+            "@babel/types": "^7.16.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0"
           }
         },
         "@babel/types": {
-          "version": "7.14.1",
+          "version": "7.16.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@babel/helper-validator-identifier": "^7.14.0",
+            "@babel/helper-validator-identifier": "^7.15.7",
             "to-fast-properties": "^2.0.0"
           }
         },
+        "@isaacs/import-jsx": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.5.5",
+            "@babel/plugin-proposal-object-rest-spread": "^7.5.5",
+            "@babel/plugin-transform-destructuring": "^7.5.0",
+            "@babel/plugin-transform-react-jsx": "^7.3.0",
+            "caller-path": "^3.0.1",
+            "find-cache-dir": "^3.2.0",
+            "make-dir": "^3.0.2",
+            "resolve-from": "^3.0.0",
+            "rimraf": "^3.0.0"
+          },
+          "dependencies": {
+            "caller-callsite": {
+              "version": "4.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "callsites": "^3.1.0"
+              }
+            },
+            "caller-path": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "caller-callsite": "^4.1.0"
+              }
+            },
+            "callsites": {
+              "version": "3.1.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
         "@types/prop-types": {
-          "version": "15.7.3",
+          "version": "15.7.4",
           "bundled": true,
           "dev": true
         },
         "@types/react": {
-          "version": "16.14.6",
+          "version": "17.0.34",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -4995,7 +5461,7 @@
           }
         },
         "@types/scheduler": {
-          "version": "0.16.1",
+          "version": "0.16.2",
           "bundled": true,
           "dev": true
         },
@@ -5010,7 +5476,19 @@
           "dev": true,
           "requires": {
             "type-fest": "^0.21.3"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "0.21.3",
+              "bundled": true,
+              "dev": true
+            }
           }
+        },
+        "ansi-regex": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
@@ -5022,11 +5500,6 @@
         },
         "ansicolors": {
           "version": "0.3.2",
-          "bundled": true,
-          "dev": true
-        },
-        "arrify": {
-          "version": "2.0.1",
           "bundled": true,
           "dev": true
         },
@@ -5055,40 +5528,19 @@
           }
         },
         "browserslist": {
-          "version": "4.16.6",
+          "version": "4.17.6",
           "bundled": true,
           "dev": true,
           "requires": {
-            "caniuse-lite": "^1.0.30001219",
-            "colorette": "^1.2.2",
-            "electron-to-chromium": "^1.3.723",
+            "caniuse-lite": "^1.0.30001274",
+            "electron-to-chromium": "^1.3.886",
             "escalade": "^3.1.1",
-            "node-releases": "^1.1.71"
+            "node-releases": "^2.0.1",
+            "picocolors": "^1.0.0"
           }
-        },
-        "caller-callsite": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "callsites": "^2.0.0"
-          }
-        },
-        "caller-path": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "caller-callsite": "^2.0.0"
-          }
-        },
-        "callsites": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
         },
         "caniuse-lite": {
-          "version": "1.0.30001223",
+          "version": "1.0.30001279",
           "bundled": true,
           "dev": true
         },
@@ -5116,6 +5568,11 @@
           "bundled": true,
           "dev": true
         },
+        "cli-boxes": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true
+        },
         "cli-cursor": {
           "version": "3.1.0",
           "bundled": true,
@@ -5133,6 +5590,14 @@
             "string-width": "^4.2.0"
           }
         },
+        "code-excerpt": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "convert-to-spaces": "^1.0.1"
+          }
+        },
         "color-convert": {
           "version": "1.9.3",
           "bundled": true,
@@ -5143,11 +5608,6 @@
         },
         "color-name": {
           "version": "1.1.3",
-          "bundled": true,
-          "dev": true
-        },
-        "colorette": {
-          "version": "1.2.2",
           "bundled": true,
           "dev": true
         },
@@ -5162,20 +5622,25 @@
           "dev": true
         },
         "convert-source-map": {
-          "version": "1.7.0",
+          "version": "1.8.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "safe-buffer": "~5.1.1"
           }
         },
+        "convert-to-spaces": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
         "csstype": {
-          "version": "3.0.8",
+          "version": "3.0.9",
           "bundled": true,
           "dev": true
         },
         "debug": {
-          "version": "4.3.1",
+          "version": "4.3.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -5183,7 +5648,7 @@
           }
         },
         "electron-to-chromium": {
-          "version": "1.3.727",
+          "version": "1.3.893",
           "bundled": true,
           "dev": true
         },
@@ -5213,7 +5678,7 @@
           "dev": true
         },
         "find-cache-dir": {
-          "version": "3.3.1",
+          "version": "3.3.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -5242,7 +5707,7 @@
           "dev": true
         },
         "glob": {
-          "version": "7.1.7",
+          "version": "7.2.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -5264,21 +5729,10 @@
           "bundled": true,
           "dev": true
         },
-        "import-jsx": {
+        "indent-string": {
           "version": "4.0.0",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "@babel/core": "^7.5.5",
-            "@babel/plugin-proposal-object-rest-spread": "^7.5.5",
-            "@babel/plugin-transform-destructuring": "^7.5.0",
-            "@babel/plugin-transform-react-jsx": "^7.3.0",
-            "caller-path": "^2.0.0",
-            "find-cache-dir": "^3.2.0",
-            "make-dir": "^3.0.2",
-            "resolve-from": "^3.0.0",
-            "rimraf": "^3.0.0"
-          }
+          "dev": true
         },
         "inflight": {
           "version": "1.0.6",
@@ -5295,28 +5749,33 @@
           "dev": true
         },
         "ink": {
-          "version": "2.7.1",
+          "version": "3.2.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "ansi-escapes": "^4.2.1",
-            "arrify": "^2.0.1",
-            "auto-bind": "^4.0.0",
-            "chalk": "^3.0.0",
+            "auto-bind": "4.0.0",
+            "chalk": "^4.1.0",
+            "cli-boxes": "^2.2.0",
             "cli-cursor": "^3.1.0",
             "cli-truncate": "^2.1.0",
+            "code-excerpt": "^3.0.0",
+            "indent-string": "^4.0.0",
             "is-ci": "^2.0.0",
-            "lodash.throttle": "^4.1.1",
-            "log-update": "^3.0.0",
-            "prop-types": "^15.6.2",
-            "react-reconciler": "^0.24.0",
-            "scheduler": "^0.18.0",
+            "lodash": "^4.17.20",
+            "patch-console": "^1.0.0",
+            "react-devtools-core": "^4.19.1",
+            "react-reconciler": "^0.26.2",
+            "scheduler": "^0.20.2",
             "signal-exit": "^3.0.2",
             "slice-ansi": "^3.0.0",
-            "string-length": "^3.1.0",
+            "stack-utils": "^2.0.2",
+            "string-width": "^4.2.2",
+            "type-fest": "^0.12.0",
             "widest-line": "^3.1.0",
             "wrap-ansi": "^6.2.0",
-            "yoga-layout-prebuilt": "^1.9.3"
+            "ws": "^7.5.5",
+            "yoga-layout-prebuilt": "^1.9.6"
           },
           "dependencies": {
             "ansi-styles": {
@@ -5328,7 +5787,7 @@
               }
             },
             "chalk": {
-              "version": "3.0.0",
+              "version": "4.1.2",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -5403,100 +5862,10 @@
             "p-locate": "^4.1.0"
           }
         },
-        "lodash.throttle": {
-          "version": "4.1.1",
+        "lodash": {
+          "version": "4.17.21",
           "bundled": true,
           "dev": true
-        },
-        "log-update": {
-          "version": "3.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "^3.2.0",
-            "cli-cursor": "^2.1.0",
-            "wrap-ansi": "^5.0.0"
-          },
-          "dependencies": {
-            "ansi-escapes": {
-              "version": "3.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "ansi-regex": {
-              "version": "4.1.0",
-              "bundled": true,
-              "dev": true
-            },
-            "cli-cursor": {
-              "version": "2.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "restore-cursor": "^2.0.0"
-              }
-            },
-            "emoji-regex": {
-              "version": "7.0.3",
-              "bundled": true,
-              "dev": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "mimic-fn": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "onetime": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "mimic-fn": "^1.0.0"
-              }
-            },
-            "restore-cursor": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "onetime": "^2.0.0",
-                "signal-exit": "^3.0.2"
-              }
-            },
-            "string-width": {
-              "version": "3.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "emoji-regex": "^7.0.1",
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^5.1.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "5.2.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^4.1.0"
-              }
-            },
-            "wrap-ansi": {
-              "version": "5.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^3.2.0",
-                "string-width": "^3.0.0",
-                "strip-ansi": "^5.0.0"
-              }
-            }
-          }
         },
         "loose-envify": {
           "version": "1.4.0",
@@ -5533,7 +5902,7 @@
           "dev": true
         },
         "minipass": {
-          "version": "3.1.3",
+          "version": "3.1.5",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -5546,7 +5915,7 @@
           "dev": true
         },
         "node-releases": {
-          "version": "1.1.71",
+          "version": "2.0.1",
           "bundled": true,
           "dev": true
         },
@@ -5592,6 +5961,11 @@
           "bundled": true,
           "dev": true
         },
+        "patch-console": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
         "path-exists": {
           "version": "4.0.0",
           "bundled": true,
@@ -5599,6 +5973,11 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "picocolors": {
+          "version": "1.0.0",
           "bundled": true,
           "dev": true
         },
@@ -5610,35 +5989,37 @@
             "find-up": "^4.0.0"
           }
         },
-        "prop-types": {
-          "version": "15.7.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.4.0",
-            "object-assign": "^4.1.1",
-            "react-is": "^16.8.1"
-          }
-        },
         "punycode": {
           "version": "2.1.1",
           "bundled": true,
           "dev": true
         },
-        "react-is": {
-          "version": "16.13.1",
+        "react": {
+          "version": "17.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-devtools-core": {
+          "version": "4.21.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "shell-quote": "^1.6.1",
+            "ws": "^7"
+          }
         },
         "react-reconciler": {
-          "version": "0.24.0",
+          "version": "0.26.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "loose-envify": "^1.1.0",
             "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "scheduler": "^0.18.0"
+            "scheduler": "^0.20.2"
           }
         },
         "redeyed": {
@@ -5677,7 +6058,7 @@
           "dev": true
         },
         "scheduler": {
-          "version": "0.18.0",
+          "version": "0.20.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -5690,8 +6071,13 @@
           "bundled": true,
           "dev": true
         },
+        "shell-quote": {
+          "version": "1.7.3",
+          "bundled": true,
+          "dev": true
+        },
         "signal-exit": {
-          "version": "3.0.3",
+          "version": "3.0.6",
           "bundled": true,
           "dev": true
         },
@@ -5733,58 +6119,37 @@
           "bundled": true,
           "dev": true
         },
-        "string-length": {
-          "version": "3.1.0",
+        "stack-utils": {
+          "version": "2.0.5",
           "bundled": true,
           "dev": true,
           "requires": {
-            "astral-regex": "^1.0.0",
-            "strip-ansi": "^5.2.0"
+            "escape-string-regexp": "^2.0.0"
           },
           "dependencies": {
-            "ansi-regex": {
-              "version": "4.1.0",
+            "escape-string-regexp": {
+              "version": "2.0.0",
               "bundled": true,
               "dev": true
-            },
-            "astral-regex": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "strip-ansi": {
-              "version": "5.2.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^4.1.0"
-              }
             }
           }
         },
         "string-width": {
-          "version": "4.2.2",
+          "version": "4.2.3",
           "bundled": true,
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "5.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "strip-ansi": {
-              "version": "6.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^5.0.0"
-              }
-            }
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
           }
         },
         "supports-color": {
@@ -5819,16 +6184,15 @@
           "dev": true
         },
         "treport": {
-          "version": "2.0.2",
+          "version": "3.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
+            "@isaacs/import-jsx": "^4.0.1",
             "cardinal": "^2.1.1",
             "chalk": "^3.0.0",
-            "import-jsx": "^4.0.0",
-            "ink": "^2.6.0",
+            "ink": "^3.2.0",
             "ms": "^2.1.2",
-            "string-length": "^3.1.0",
             "tap-parser": "^10.0.1",
             "unicode-length": "^2.0.2"
           },
@@ -5879,7 +6243,7 @@
           }
         },
         "type-fest": {
-          "version": "0.21.3",
+          "version": "0.12.0",
           "bundled": true,
           "dev": true
         },
@@ -5925,11 +6289,6 @@
             "strip-ansi": "^6.0.0"
           },
           "dependencies": {
-            "ansi-regex": {
-              "version": "5.0.0",
-              "bundled": true,
-              "dev": true
-            },
             "ansi-styles": {
               "version": "4.3.0",
               "bundled": true,
@@ -5950,19 +6309,16 @@
               "version": "1.1.4",
               "bundled": true,
               "dev": true
-            },
-            "strip-ansi": {
-              "version": "6.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^5.0.0"
-              }
             }
           }
         },
         "wrappy": {
           "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "ws": {
+          "version": "7.5.5",
           "bundled": true,
           "dev": true
         },
@@ -6037,9 +6393,9 @@
       }
     },
     "tcompare": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/tcompare/-/tcompare-5.0.6.tgz",
-      "integrity": "sha512-OvO7omN/wkdsKzmOqr3sQFfLbghs/2X5mwSkcfgRiXZshfPnTsAs3IRf1RixR/Pff26qG/r9ogcZMpV0YdeGXg==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/tcompare/-/tcompare-5.0.7.tgz",
+      "integrity": "sha512-d9iddt6YYGgyxJw5bjsN7UJUO1kGOtjSlNy/4PoGYAjQS5pAT/hzIoLf1bZCw+uUxRmZJh7Yy1aA7xKVRT9B4w==",
       "dev": true,
       "requires": {
         "diff": "^4.0.2"
@@ -6147,11 +6503,39 @@
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
     },
+    "trim-newlines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
+      "dev": true
+    },
     "trivial-deferred": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trivial-deferred/-/trivial-deferred-1.0.1.tgz",
       "integrity": "sha1-N21NKdlR1jaKb3oK6FwvTV4GWPM=",
       "dev": true
+    },
+    "tsd": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.19.0.tgz",
+      "integrity": "sha512-DlYCjjRVspfSAC+9X1NUDqPj0PtsVjUSyC4/OJpCGnY2Mtg0ddc+opckmnLV3RhUBpVuAAOrz661v+QSJwINkQ==",
+      "dev": true,
+      "requires": {
+        "@tsd/typescript": "~4.5.2",
+        "eslint-formatter-pretty": "^4.1.0",
+        "globby": "^11.0.1",
+        "meow": "^9.0.0",
+        "path-exists": "^4.0.0",
+        "read-pkg-up": "^7.0.0"
+      },
+      "dependencies": {
+        "@tsd/typescript": {
+          "version": "4.5.4",
+          "resolved": "https://registry.npmjs.org/@tsd/typescript/-/typescript-4.5.4.tgz",
+          "integrity": "sha512-iDlLkdg3sCjUSNdoUCsYM/SXheHrdxHsR6msIkbFDW4pV6gHTMwg/8te/paLtywDjGL4S4ByDdUKA3RbfdBX0g==",
+          "dev": true
+        }
+      }
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -6202,6 +6586,12 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typescript": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "dev": true
     },
     "unicode-length": {
       "version": "2.0.2",
@@ -6302,6 +6692,16 @@
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
           "dev": true
         }
+      }
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "verror": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "lint": "eslint index.js test/index.test.js",
     "nocov": "tap test/*.js",
-    "test": "nyc --reporter=lcov tap ./test/*.js",
+    "test": "nyc --reporter=lcov tap ./test/*.js && tsd",
     "coverage": "nyc tap ./test/*.js && nyc check-coverage --statements 100 --functions 100 --lines 100 --branches 100 --report html"
   },
   "repository": {
@@ -48,6 +48,11 @@
     "is-node-stream": "^1.0.0",
     "jest": "^27.3.1",
     "nyc": "^15.1.0",
-    "tap": "^15.0.9"
+    "tap": "^15.1.2",
+    "tsd": "^0.19.0",
+    "typescript": "^4.5.2"
+  },
+  "tsd": {
+    "directory": "test"
   }
 }

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -1,0 +1,113 @@
+import * as AWS from 'aws-sdk';
+import { AWSError } from 'aws-sdk';
+import { ListObjectsV2Request } from 'aws-sdk/clients/s3';
+import { expectError, expectType } from 'tsd';
+import { mock, remock, restore, setSDK, setSDKInstance } from '../index';
+
+const awsError: AWSError = {
+    name: 'AWSError',
+    message: 'message',
+    code: 'code',
+    time: new Date(),
+};
+
+expectType<void>(mock('S3', 'listObjectsV2', (params, callback) => {
+    expectType<ListObjectsV2Request>(params);
+
+    const output: AWS.S3.ListObjectsV2Output = {
+        Name: params.Bucket,
+        MaxKeys: params.MaxKeys,
+        Delimiter: params.Delimiter,
+        Prefix: params.Prefix,
+        KeyCount: 1,
+        IsTruncated: false,
+        ContinuationToken: params.ContinuationToken,
+        Contents: [
+            {
+                LastModified: new Date(),
+                ETag: '"668d791b0c7d6a7f0f86c269888b4546"',
+                StorageClass: 'STANDARD',
+                Key: 'aws-sdk-mock/index.js',
+                Size: 8524,
+            },
+        ]
+    };
+    expectType<void>(callback(undefined, output));
+
+    expectType<void>(callback(undefined, {}));
+
+    expectError(callback(null, output));
+
+    expectError(callback(undefined));
+
+    expectType<void>(callback(awsError));
+
+    expectError(callback(awsError, output));
+}));
+
+expectError(mock('S3', 'describeObjects', (params, callback) => {
+    expectType<never>(params);
+    expectType<never>(callback);
+}));
+
+expectType<void>(mock('DynamoDB', 'getItem', 'anything could happen'));
+
+expectError(mock('StaticDB', 'getItem', "it couldn't"));
+
+expectType<void>(remock('EC2', 'stopInstances', (params, callback) => {
+    // $ExpectType string[]
+    const instanceIds = params.InstanceIds;
+    expectType<string[]>(instanceIds);
+
+    const output: AWS.EC2.StopInstancesResult = {
+        StoppingInstances: instanceIds.map(id => ({
+            InstanceId: id,
+            PreviousState: { Name: 'running' },
+            CurrentState: { Name: 'stopping' },
+        })),
+    };
+    expectType<void>(callback(undefined, output));
+
+    expectType<void>(callback(undefined, {}));
+
+    expectError(callback(null, output));
+
+    expectError(callback(undefined));
+
+    expectType<void>(callback(awsError));
+
+    expectError(callback(awsError, output));
+}));
+
+expectType<void>(remock('Snowball', 'makeRequest', undefined));
+expectError(remock('Snowball', 'throwRequest', undefined));
+
+expectType<void>(restore('Pricing', 'getProducts'));
+
+expectError(restore('Pricing', 'borrowMoney'));
+
+expectType<void>(restore('KMS'));
+
+expectError(restore('Skynet'));
+
+expectError(restore(42));
+
+expectType<void>(restore());
+
+expectError(restore(null));
+
+expectType<void>(setSDK('aws-sdk'));
+
+expectType<void>(setSDKInstance(AWS));
+
+expectError(setSDKInstance(import('aws-sdk')));
+
+async function foo() {
+    expectType<void>(setSDKInstance(await import('aws-sdk')));
+}
+
+expectError(setSDKInstance(AWS.S3));
+
+import allClients = require('aws-sdk/clients/all');
+
+expectError(setSDKInstance(allClients));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "strict": true,
+        "noEmit": true,
+    },
+    "exclude": [
+        "node_modules/**/*"
+    ]
+}


### PR DESCRIPTION
This is based on the work of https://github.com/dwyl/aws-sdk-mock/pull/180, but seeing as that PR is most likely dead I opted to start a new one.

Main differences with #180:
- No merge conflicts with main
- Use tsd instead of dtslint for cleaner test setup