### PR TITLE
Fixes #256

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,9 +127,12 @@ function wrapTestStubReplaceFn(replace) {
       cb = params;
       params = {};
     }
+    // Spy on the users callback so we can later on determine if it has been called in their replace
     const cbSpy = sinon.spy(cb);
     try {
-      const result = replace(params, cbSpy);
+      // Call the users replace, check how many parameters it expects to determine if we should pass in callback only, or also parameters
+      const result = replace.length === 1 ? replace(cbSpy) : replace(params, cbSpy);
+      // If the users replace already called the callback, there's no more need for us do it.
       if (cbSpy.called) {
           return;
       }

--- a/index.js
+++ b/index.js
@@ -122,8 +122,17 @@ function wrapTestStubReplaceFn(replace) {
   }
 
   return (params, cb) => {
+    // If only one argument is provided, it is the callback
+    if (!cb) {
+      cb = params;
+      params = {};
+    }
+    const cbSpy = sinon.spy(cb);
     try {
-      const result = replace(params);
+      const result = replace(params, cbSpy);
+      if (cbSpy.called) {
+          return;
+      }
       if (typeof result.then === 'function') {
         result.then(val => cb(undefined, val), err => cb(err));
       } else {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -688,6 +688,17 @@ test('AWS.mock function should mock AWS service and method on the service', func
     });
   });
 
+  t.test('mock function replaces method with a jest mock with implementation expecting only a callback', function(st) {
+    const jestMock = jest.fn((cb) => cb(null, 'item'));
+    awsMock.mock('DynamoDB', 'getItem', jestMock);
+    const db = new AWS.DynamoDB();
+    db.getItem(function(err, data){
+      st.equal(jestMock.mock.calls.length, 1);
+      st.equal(data, 'item');
+      st.end();
+    });
+  });
+
   t.end();
 });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -620,6 +620,17 @@ test('AWS.mock function should mock AWS service and method on the service', func
     });
   });
 
+  t.test('mock function replaces method with a jest mock returning successfully and allows mocked method to be called with only callback', function(st) {
+    const jestMock = jest.fn().mockReturnValue('message');
+    awsMock.mock('DynamoDB', 'getItem', jestMock);
+    const db = new AWS.DynamoDB();
+    db.getItem(function(err, data){
+      st.equal(data, 'message');
+      st.equal(jestMock.mock.calls.length, 1);
+      st.end();
+    });
+  });
+
   t.test('mock function replaces method with a jest mock and resolves successfully', function(st) {
     const jestMock = jest.fn().mockResolvedValue('message');
     awsMock.mock('DynamoDB', 'getItem', jestMock);
@@ -632,7 +643,7 @@ test('AWS.mock function should mock AWS service and method on the service', func
   });
 
   t.test('mock function replaces method with a jest mock and fails successfully', function(st) {
-    const jestMock = jest.fn().mockImplementation(() => {
+    const jestMock = jest.fn(() => {
       throw new Error('something went wrong')
     });
     awsMock.mock('DynamoDB', 'getItem', jestMock);
@@ -651,6 +662,28 @@ test('AWS.mock function should mock AWS service and method on the service', func
     db.getItem({}, function(err){
       st.equal(err.message, 'something went wrong');
       st.equal(jestMock.mock.calls.length, 1);
+      st.end();
+    });
+  });
+
+  t.test('mock function replaces method with a jest mock with implementation', function(st) {
+    const jestMock = jest.fn((params, cb) => cb(null, 'item'));
+    awsMock.mock('DynamoDB', 'getItem', jestMock);
+    const db = new AWS.DynamoDB();
+    db.getItem({}, function(err, data){
+      st.equal(jestMock.mock.calls.length, 1);
+      st.equal(data, 'item');
+      st.end();
+    });
+  });
+
+  t.test('mock function replaces method with a jest mock with implementation and allows mocked method to be called with only callback', function(st) {
+    const jestMock = jest.fn((params, cb) => cb(null, 'item'));
+    awsMock.mock('DynamoDB', 'getItem', jestMock);
+    const db = new AWS.DynamoDB();
+    db.getItem(function(err, data){
+      st.equal(jestMock.mock.calls.length, 1);
+      st.equal(data, 'item');
       st.end();
     });
   });


### PR DESCRIPTION
This fixes the issues caused by 5.5.0 (#256):

- Correctly handles jest mock functions that define an implementation of their own
- The wrapping replacement function can now handle being called with only one parameter (the callback)