### PR TITLE
#259: patch nested client names

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,3 @@
-// TypeScript Version: 3.2
 import { Request, AWSError } from 'aws-sdk/lib/core';
 import AWS = require('aws-sdk/clients/all');
 
@@ -23,17 +22,20 @@ export interface AWSMethod<P, D> {
 
 export type Callback<D> = (err: AWSError | undefined, data: D) => void;
 
+export type ReplaceFn<C extends ClientName, M extends MethodName<C>> = (params: AWSRequest<C, M>, callback: AWSCallback<C, M>) => void
+
 export function mock<C extends ClientName, M extends MethodName<C>>(
   service: C,
   method: M,
-  replace: (params: AWSRequest<C, M>, callback: AWSCallback<C, M>) => void
+  replace: ReplaceFn<C, M>,
 ): void;
+export function mock<C extends ClientName, NC extends NestedClientName<C>>(service: NestedClientFullName<C, NC>, method: NestedMethodName<C, NC>, replace: any): void;
 export function mock<C extends ClientName>(service: C, method: MethodName<C>, replace: any): void;
 
 export function remock<C extends ClientName, M extends MethodName<C>>(
   service: C,
   method: M,
-  replace: (params: AWSRequest<C, M>, callback: AWSCallback<C, M>) => void
+  replace: ReplaceFn<C, M>,
 ): void;
 export function remock<C extends ClientName>(service: C, method: MethodName<C>, replace: any): void;
 
@@ -41,3 +43,20 @@ export function restore<C extends ClientName>(service?: C, method?: MethodName<C
 
 export function setSDK(path: string): void;
 export function setSDKInstance(instance: typeof import('aws-sdk')): void;
+
+/**
+ * The SDK defines a class for each service as well as a namespace with the same name.
+ * Nested clients, e.g. DynamoDB.DocumentClient, are defined on the namespace, not the class.
+ * That is why we need to fetch these separately as defined below in the NestedClientName<C> type
+ * 
+ * The NestedClientFullName type supports validating strings representing a nested clients name in dot notation
+ * 
+ * We add the ts-ignore comments to avoid the type system to trip over the many possible values for NestedClientName<C>
+ */
+export type NestedClientName<C extends ClientName> = keyof typeof AWS[C];
+// @ts-ignore
+export type NestedClientFullName<C extends ClientName, NC extends NestedClientName<C>> = `${C}.${NC}`;
+// @ts-ignore
+export type NestedClient<C extends ClientName, NC extends NestedClientName<C>> = InstanceType<(typeof AWS)[C][NC]>;
+// @ts-ignore
+export type NestedMethodName<C extends ClientName, NC extends NestedClientName<C>> = keyof ExtractMethod<NestedClient<C, NC>>;

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -51,6 +51,10 @@ expectError(mock('S3', 'describeObjects', (params, callback) => {
 }));
 
 expectType<void>(mock('DynamoDB', 'getItem', 'anything could happen'));
+expectType<void>(mock('DynamoDB.DocumentClient', 'get', 'anything could happen'));
+
+expectError(mock('DynamoDB.DocumentServer', 'get', 'nothing can happen'));
+expectError(mock('DynamoDB.DocumentClient', 'unknown', 'nothing can happen'));
 
 expectError(mock('StaticDB', 'getItem', "it couldn't"));
 


### PR DESCRIPTION
This fixes #259. Using the dot notation to mock nested client names, e.g. `DynamoDB.DocumentClient` and their respective methods are now correctly validated by TypeScript.

This fix is not yet polished (I would like to remove those `@ts-ignore` comments later on), but at least users of 5.6.0 will no longer be blocked.

It can be released as a patch version