### PR TITLE
Mocked service should allow abort call

### DIFF
--- a/index.js
+++ b/index.js
@@ -225,7 +225,8 @@ function mockServiceMethod(service, client, method, replace) {
       },
       send: function(callback) {
         callback(storedResult.reject, storedResult.resolve);
-      }
+      },
+      abort: function(){}
     };
 
     // different locations for the paramValidation property

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -699,6 +699,14 @@ test('AWS.mock function should mock AWS service and method on the service', func
     });
   });
 
+  t.test('Mocked service should allow abort call', function (st) {
+    awsMock.mock('S3', 'upload');
+    const s3 = new AWS.S3();
+    const req = s3.upload({}, {message: 'test'});
+    req.abort();
+    st.end();
+  });
+
   t.end();
 });
 


### PR DESCRIPTION
Mock abort() call as it exists in original sdk
https://github.com/aws/aws-sdk-js/blob/master/lib/s3/managed_upload.js#L250