### PR TITLE
[PR] Fixing typescript path not resolving

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-sdk-mock",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-sdk-mock",
-      "version": "6.0.0",
+      "version": "6.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "aws-sdk": "^2.1231.0",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,15 @@
 {
   "name": "aws-sdk-mock",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Functions to mock the JavaScript aws-sdk",
   "type": "module",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",
-  "files": ["dist", "README.md", "LICENSE"],
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "lint": "tsc",
     "nocov": "ts-mocha test/**/*.spec.ts",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "6.0.0",
   "description": "Functions to mock the JavaScript aws-sdk",
   "type": "module",
-  "main": "dist/index.js",
+  "main": "dist/index.cjs",
   "types": "dist/index.d.ts",
+  "files": ["dist", "README.md", "LICENSE"],
   "scripts": {
     "lint": "tsc",
     "nocov": "ts-mocha test/**/*.spec.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,6 +33,7 @@
   },
   "exclude": [
     "babel.config.cjs",
-    "node_modules/**/*"
+    "node_modules/**/*",
+    "dist/**/*",
   ]
 }


### PR DESCRIPTION
fixes #403 

I'm running `npm pack` and `npx publint` to check if the package is publishable.

I've made some changes to to the `tsconfig.json` so the proper files are uploaded and the `types` and `main` fields from `package.json` are pointing to the right path.