### PR TITLE
[PR] Removing "type: module" and bundling .mjs files.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-sdk-mock",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-sdk-mock",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "aws-sdk": "^2.1231.0",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "aws-sdk-mock",
   "version": "6.0.1",
   "description": "Functions to mock the JavaScript aws-sdk",
-  "type": "module",
-  "main": "dist/index.cjs",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -15,7 +15,7 @@
     "nocov": "ts-mocha test/**/*.spec.ts",
     "test": "nyc ts-mocha test/**/*.spec.ts && tsd",
     "coverage": "nyc --report html ts-mocha test/**/*.spec.ts && open coverage/index.html",
-    "build": "tsup src/index.ts --format cjs, esm, --dts"
+    "build": "tsup src/index.ts --format esm,cjs --dts"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-sdk-mock",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "Functions to mock the JavaScript aws-sdk",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
fixes #411 

Removes the `"type": "module" from `package.json` and subsequently bundles the project into `.js` and `.mjs` files (`cjs` and `esm`, respectively), accommodating Javascript projects that are `CommonJS`-based.
