### PR TITLE
[PR] Exporting default types properly so it matches the javascript file.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-sdk-mock",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-sdk-mock",
-      "version": "6.0.2",
+      "version": "6.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "aws-sdk": "^2.1231.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "nocov": "ts-mocha test/**/*.spec.ts",
     "test": "nyc ts-mocha test/**/*.spec.ts && tsd",
     "coverage": "nyc --report html ts-mocha test/**/*.spec.ts && open coverage/index.html",
-    "build": "tsup src/index.ts --format esm,cjs --dts"
+    "build": "tsup"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-sdk-mock",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "description": "Functions to mock the JavaScript aws-sdk",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,10 +11,9 @@
 import type { SinonExpectation, SinonSpy, SinonStubbedInstance } from 'sinon';
 import sinon from 'sinon';
 import traverse from 'traverse';
+import { Readable } from 'stream';
 
 import AWS_SDK from 'aws-sdk';
-
-import { Readable } from 'stream';
 
 import {
   type ReplaceFn,
@@ -531,4 +530,4 @@ function restoreMethod<C extends ClientName, M extends MethodName<C>>(service: C
   }
 })();
 
-export default AWS;
+export = AWS;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import { type Request, type AWSError } from 'aws-sdk/lib/core.js';
-import AWS = require('aws-sdk/clients/all');
+import AWS from 'aws-sdk/clients/all';
 import {type SinonStub } from 'sinon';
 
 /*

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+    format: ['cjs', 'esm'],
+    entry: ['src/index.ts'],
+    dts: true,
+    shims: true,
+    skipNodeModulesBundle: true,
+    clean: true,
+})


### PR DESCRIPTION
fixes #411 

The problem was related to how the `default export` was being treated from Typescript to Javascript. They didn't match, so what happened is that, after transpiling the Typescript to Javascript, the `js` files would have a different way of exporting the default `AWS` variable than what was described in the Typescript files. Read https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/FalseExportDefault.md for a comprehensive overview.

This PR fixes this and changes the way `AWS` is exported to `export = AWS` (instead of `export default AWS`).

In addition to this, the bundle configuration from `tsup` is now explicit.