### PR TITLE
chore: neotraverse 0.6.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "aws-sdk": "^2.1231.0",
-        "neotraverse": "^0.6.11",
+        "neotraverse": "^0.6.15",
         "sinon": "^18.0.0"
       },
       "devDependencies": {
@@ -4391,12 +4391,12 @@
       "dev": true
     },
     "node_modules/neotraverse": {
-      "version": "0.6.11",
-      "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.11.tgz",
-      "integrity": "sha512-OdydhNAkoRxXyxz1d8Cx2rQS0wfTcoSlBNIuv/PMC/0CrwTYUBMy+kIa7h3y18lVyvgARazb4ugVZ5n/aly2PA==",
+      "version": "0.6.15",
+      "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.15.tgz",
+      "integrity": "sha512-HZpdkco+JeXq0G+WWpMJ4NsX3pqb5O7eR9uGz3FfoFt+LYzU8iRWp49nJtud6hsDoywM8tIrDo3gjgmOqJA8LA==",
       "license": "MIT",
       "engines": {
-        "node": ">= 18"
+        "node": ">= 10"
       }
     },
     "node_modules/nise": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "homepage": "https://github.com/dwyl/aws-sdk-mock#readme",
   "dependencies": {
     "aws-sdk": "^2.1231.0",
-    "neotraverse": "^0.6.11",
+    "neotraverse": "^0.6.15",
     "sinon": "^18.0.0"
   },
   "tsd": {


### PR DESCRIPTION
Multiple updates since 0.6.11 which add support for WebPack 4, TypeScript 3 and 4(less than 4.5) and much more fixes on the package level