### PR TITLE
PR: Bump Version to `6.2` for CVE 2024 45296 ref: #477

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4209,12 +4209,12 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-sdk-mock",
-  "version": "6.1.1",
+  "version": "6.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-sdk-mock",
-      "version": "6.1.1",
+      "version": "6.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "aws-sdk": "^2.1231.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-sdk-mock",
-  "version": "6.1.1",
+  "version": "6.2.0",
   "description": "Functions to mock the JavaScript aws-sdk",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
This micro-PR is just to update the version of the package from `6.1.1` to `6.2` to
+ [x] release a new version to mitigate the CVE noted by @MarcioMeier in #477 🔐 

Already published to NPM: `aws-sdk-mock@6.2.0`: https://www.npmjs.com/package/aws-sdk-mock/v/6.2.0 📦 🚀 
Security fixes are always done `ASAP` to avoid anyone down-stream being affected. 🏁 