### PR TITLE
[PR] Bump to version `6.2.1` 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-sdk-mock",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-sdk-mock",
-      "version": "6.2.0",
+      "version": "6.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "aws-sdk": "^2.1231.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-sdk-mock",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "description": "Functions to mock the JavaScript aws-sdk",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
As per https://github.com/dwyl/aws-sdk-mock/pull/515#issuecomment-2586505274, this bumps the version.

It has already been published -> https://www.npmjs.com/package/aws-sdk-mock/v/6.2.1